### PR TITLE
Update performance benchmarks and key achievements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,22 +448,22 @@ FairyScope(
 
 ## Performance
 
-Fairy is designed for performance. Benchmark results comparing with popular state management solutions (averaged over 5 runs with engine warm-up):
+Fairy is designed for performance. Benchmark results comparing with popular state management solutions (median of 5 measurements per test, averaged across 5 complete runs):
 
 | Category | Fairy | Provider | Riverpod |
 |----------|-------|----------|----------|
-| Widget Performance (1000 interactions) | 101.8% | 106.2% | **100%** 🥇 |
-| Memory Management (50 cycles) | **100%** 🥇 | 106.7% | 100.5% |
-| Selective Rebuild (explicit Bind) | **100%** 🥇 | 134.0% | 122.6% |
-| Rebuild Performance (auto-binding) | **100%** 🥇 | 103.9% | 100.9% |
+| Widget Performance (1000 interactions) | 116.5% | 104.9% | **100%** 🥇 |
+| Memory Management (50 cycles) | 113.9% | 105.1% | **100%** 🥇 |
+| Selective Rebuild (explicit Bind) | **100%** 🥇 | 138.3% | 130.2% |
+| Auto-tracking Rebuild (Bind.viewModel) | **100%** 🥇 | 132.4% | 124.5% |
 
 ### Key Achievements
-- **🥇 Best Memory Management** - 0.5% faster than Riverpod, 6.7% faster than Provider
-- **🥇 Fastest Selective Rebuilds** - 22.6-34% faster
-- **🥇 Fastest Auto-binding** - 0.9-3.9% faster with 100% rebuild efficiency
-- **Unique**: Only framework achieving 100% selective efficiency vs 33% for Provider/Riverpod
+- **🥇 Fastest Selective Rebuilds** - 30-38% faster with explicit binding
+- **🥇 Fastest Auto-tracking** - 24-32% faster while maintaining 100% rebuild efficiency
+- **Unique**: Only framework achieving 100% selective efficiency (500 rebuilds) vs 33% for Provider/Riverpod (1500 rebuilds)
+- **Memory**: **Intentional design decision** to use 14% more memory in exchange for 24-38% faster rebuilds (both auto-tracking and selective binding) plus superior developer experience with command auto-tracking
 
-*Lower is better. Percentages relative to the fastest framework in each category.*
+*Lower is better. Percentages relative to the fastest framework in each category. Benchmarked on v1.4.0.*
 
 ## Example
 


### PR DESCRIPTION
This pull request updates the performance section of the `README.md` to reflect new benchmarking results and clarify the methodology. The changes provide more accurate and transparent performance comparisons, introduce a new benchmark category, and explain the memory usage tradeoff.

Performance benchmark updates:

* Updated the benchmarking methodology description to clarify that results are the median of 5 measurements per test, averaged across 5 runs, rather than averaged over 5 runs with engine warm-up.
* Revised benchmark results in the performance table to reflect new measurements, including updated percentages for `Widget Performance`, `Memory Management`, and `Selective Rebuild`, and replaced `Rebuild Performance (auto-binding)` with a new category: `Auto-tracking Rebuild (Bind.viewModel)`.

Key achievements and tradeoffs:

* Updated the "Key Achievements" section to highlight new performance advantages, clarify the unique selective efficiency, and explain the intentional memory usage increase for faster rebuilds and better developer experience.
* Added a note specifying that benchmark results are based on version v1.4.0 for improved transparency.