### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A lightweight MVVM framework for Flutter with strongly-typed reactive data bindi
 
 ```yaml
 dependencies:
-  fairy: ^3.0.0+1
+  fairy: ^3.0.1
 ```
 
 ## Quick Start

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -17,7 +17,7 @@ The benchmarks compare three frameworks:
 - **📦 Provider**: Popular state management solution  
 - **🏗️ Riverpod**: Modern reactive framework
 
-### Latest Results (v1.4.0)
+### Latest Results (v3.0.1)
 
 Performance metrics (median of 5 measurements per test, averaged across 5 complete runs):
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 3.0.1
+
+### Bug Fixes
+
+- **Fixed `DependencyTracker` cross-widget tracking corruption** — When multiple `Bind.viewModel` widgets coexisted in the same tree, the global `_currentContext` could be overwritten by sibling widgets, causing deferred builder accesses (e.g., `ListView.builder`'s `itemBuilder`) to be attributed to the wrong widget. The fix introduces a 3-layer tracking approach:
+  - `_TrackingContextElement` with `update()`/`performRebuild()` overrides for build-phase tracking
+  - `_BoxTrackingRenderBox` / `_SliverTrackingRenderBox` for initial layout-phase tracking (auto-detects sliver vs box context)
+  - Guard sessions in `Bind` and `Command` widget `build()` methods via `DependencyTracker.track()` for session isolation
+
+### New Features
+
+- **Duplicate ViewModel type assertion** — `Bind.viewModel2`, `Bind.viewModel3`, `Bind.viewModel4` (and their direct `BindViewModel2/3/4` constructors) now throw an `AssertionError` in debug mode when the same ViewModel type is used for multiple type parameters (e.g., `Bind.viewModel2<FooVM, FooVM>` will fail). Use `Bind.viewModel` instead for a single ViewModel type.
+- **Exported `BindViewModel4`** — `BindViewModel4` is now publicly exported from the package for advanced users who prefer direct constructor usage.
+
+### Tests
+
+- Added 40 dependency tracker edge-case tests covering slivers, multi-widget isolation, nested Bind/Command, conditional rendering, rapid/stress scenarios, session stack integrity, and `Bind.viewModel2/3/4` deferred tracking
+- Added 17 duplicate ViewModel type assertion tests covering all pair combinations for `viewModel2`, `viewModel3`, and `viewModel4`
+
 ## 3.0.0+1
 
 ### Documentation

--- a/src/README.md
+++ b/src/README.md
@@ -35,7 +35,7 @@ A lightweight MVVM framework for Flutter with strongly-typed reactive data bindi
 
 ```yaml
 dependencies:
-  fairy: ^3.0.0+1
+  fairy: ^3.0.1
 ```
 
 ## Quick Start
@@ -838,7 +838,7 @@ Fairy is designed for performance. Benchmark results comparing with popular stat
 - **Unique**: Only framework achieving 100% selective efficiency (500 rebuilds) vs 33% for Provider/Riverpod (1500 rebuilds)
 - **Memory**: **Intentional design decision** to use 13% more memory in exchange for 26-34% faster rebuilds (both auto-tracking and selective binding) plus superior developer experience with command auto-tracking
 
-*Lower is better. Percentages relative to the fastest framework in each category. Benchmarked on v2.0.0.*
+*Lower is better. Percentages relative to the fastest framework in each category. Benchmarked on v3.0.1.*
 
 ## Example
 

--- a/src/lib/fairy.dart
+++ b/src/lib/fairy.dart
@@ -74,7 +74,7 @@ export 'src/locator/fairy_resolver.dart' show Fairy;
 // UI binding widgets
 export 'src/ui/bind_widget.dart' show Bind;
 export 'src/ui/bind_viewmodel_widget.dart'
-    show BindViewModel, BindViewModel2, BindViewModel3;
+    show BindViewModel, BindViewModel2, BindViewModel3, BindViewModel4;
 export 'src/ui/command_widget.dart' show Command, CommandWithParam;
 export 'src/ui/fairy_bridge.dart' show FairyBridge;
 // Utilities

--- a/src/lib/src/internal/dependency_tracker.dart
+++ b/src/lib/src/internal/dependency_tracker.dart
@@ -252,8 +252,7 @@ class _TrackingLayoutWidget extends StatelessWidget {
   /// Detects whether this widget is in a context that expects sliver children.
   /// If so, inserting a RenderProxyBox (a RenderBox) would cause a type error.
   static bool _isInSliverContext(BuildContext context) {
-    final parent =
-        context.findAncestorRenderObjectOfType<RenderObject>();
+    final parent = context.findAncestorRenderObjectOfType<RenderObject>();
     if (parent == null) return false;
 
     // RenderViewport is a RenderBox whose children must be RenderSlivers

--- a/src/lib/src/internal/dependency_tracker.dart
+++ b/src/lib/src/internal/dependency_tracker.dart
@@ -1,5 +1,6 @@
 import 'package:fairy/src/core/observable_node.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 /// Internal dependency tracker using stack-based sessions with
@@ -10,18 +11,21 @@ import 'package:flutter/widgets.dart';
 /// Stack-based (not Zone-based) for performance and stability.
 /// InheritedWidget fallback enables deferred callbacks (ListView.builder)
 /// to report property accesses.
+///
+/// Custom [InheritedElement] with [performRebuild] override ensures
+/// build-phase child updates (SliverMultiBoxAdaptorElement.performRebuild)
+/// capture accesses via the stack, isolating each widget's session correctly.
 @internal
 class DependencyTracker {
   // Stack of active tracking sessions (Flutter is single-threaded)
   static final List<_TrackingSession> _stack = [];
 
-  // BuildContext for lazy builder tracking fallback
-  static BuildContext? _currentContext;
-
-  /// Sets BuildContext for lazy builder tracking. Internal use only.
-  static void setCurrentContext(BuildContext? context) {
-    _currentContext = context;
-  }
+  // Stack of active context elements for layout-phase fallback.
+  // Each _TrackingContextElement pushes itself on mount and pops on unmount.
+  // The LAST element in the list is the most deeply nested, which is the
+  // correct target for layout-phase deferred callbacks since layout
+  // runs bottom-up (leaf → root).
+  static final List<_TrackingContextElement> _contextStack = [];
 
   /// Whether there is an active tracking session.
   /// Optimizes reportAccess() by allowing early returns.
@@ -30,25 +34,26 @@ class DependencyTracker {
   /// Reports ObservableNode access during current session.
   ///
   /// No-op if no session is active. Supports two modes:
-  /// 1. Stack-based (primary): Synchronous build execution
-  /// 2. Context-based (fallback): Deferred callbacks via InheritedWidget
+  /// 1. Stack-based (primary): Synchronous build execution and
+  ///    build-phase child updates (via performRebuild override)
+  /// 2. Context-stack fallback: Layout-phase deferred callbacks
+  ///    walk the context stack to find the correct session
   static void reportAccess(ObservableNode node) {
-    // Early exit if no tracking session active (optimization)
-    if (_stack.isEmpty && _currentContext == null) {
-      return;
-    }
-
-    // Stack-based session (primary - synchronous build)
+    // Stack-based session (primary - synchronous build + performRebuild)
     if (_stack.isNotEmpty) {
       _stack.last._accessed.add(node);
       return;
     }
 
-    // Context-based fallback (deferred callbacks like itemBuilder)
-    final context = _currentContext;
-    if (context != null) {
-      final session = _TrackingContextWidget._maybeOf(context);
-      session?._accessed.add(node);
+    // Context-stack fallback (layout-phase deferred callbacks).
+    // During layout, invokeLayoutCallback runs from within a specific
+    // SliverMultiBoxAdaptorElement. The last context in _contextStack
+    // is the most deeply nested tracking context — which is the correct
+    // parent for that sliver element.
+    if (_contextStack.isNotEmpty) {
+      final element = _contextStack.last;
+      final session = (element.widget as _TrackingContextWidget).session;
+      session._accessed.add(node);
     }
   }
 
@@ -57,8 +62,8 @@ class DependencyTracker {
   /// Returns: (result, accessed nodes, optional session for deferred tracking).
   /// Exceptions preserve partial tracking before re-throwing.
   ///
-  /// When [wrapWithContext] is true, wraps result with InheritedWidget
-  /// to enable lazy builder callbacks to report accesses.
+  /// When [wrapWithContext] is true, wraps result with an InheritedWidget
+  /// that enables both build-phase and layout-phase deferred tracking.
   static (T result, Set<ObservableNode> accessed, _TrackingSession? session)
       track<T>(
     T Function() fn, {
@@ -70,12 +75,19 @@ class DependencyTracker {
     try {
       final result = fn();
 
-      // Wrap with InheritedWidget to enable deferred callback tracking
+      // Wrap with tracking widgets to enable deferred callback tracking:
+      // 1. _TrackingContextWidget (InheritedWidget): Custom element pushes
+      //    session during update/performRebuild for build-phase tracking
+      // 2. _TrackingLayoutWidget: Auto-detects box/sliver context and
+      //    inserts RenderProxyBox for initial layout-phase tracking
       if (wrapWithContext && result is Widget) {
         return (
           _TrackingContextWidget(
             session: session,
-            child: result,
+            child: _TrackingLayoutWidget(
+              session: session,
+              child: result,
+            ),
           ) as T,
           Set.from(session._accessed), // Snapshot for comparison
           session // For checking deferred accesses
@@ -115,8 +127,17 @@ class _TrackingSession {
 
 /// InheritedWidget propagating tracking session down the tree.
 /// Enables deferred callbacks (itemBuilder) to report accesses.
-/// Phase 2.2 optimization: Captures BuildContext directly in initState.
-/// Internal use only.
+///
+/// Uses a custom [_TrackingContextElement] that:
+/// 1. Pushes session onto stack during [update] and [performRebuild] —
+///    covers build-phase child updates (SliverMultiBoxAdaptorElement)
+/// 2. Registers on [_contextStack] on mount — covers layout-phase
+///    deferred callbacks as fallback
+///
+/// The performRebuild override ensures each widget's session is correctly
+/// isolated on the stack during the recursive element tree update,
+/// preventing cross-widget tracking corruption when multiple Bind.viewModel
+/// widgets exist in the same tree.
 class _TrackingContextWidget extends InheritedWidget {
   final _TrackingSession session;
 
@@ -124,14 +145,6 @@ class _TrackingContextWidget extends InheritedWidget {
     required this.session,
     required super.child,
   });
-
-  /// Retrieves nearest tracking session from widget tree.
-  /// Used by reportAccess() as fallback for deferred callbacks.
-  static _TrackingSession? _maybeOf(BuildContext context) {
-    return context
-        .dependOnInheritedWidgetOfExactType<_TrackingContextWidget>()
-        ?.session;
-  }
 
   @override
   bool updateShouldNotify(_TrackingContextWidget oldWidget) {
@@ -144,22 +157,170 @@ class _TrackingContextWidget extends InheritedWidget {
   }
 }
 
-/// Custom Element that captures BuildContext on mount.
-/// Phase 2.2 optimization: Eliminates _ContextSetter StatefulWidget overhead.
+/// Custom InheritedElement that provides two tracking mechanisms:
+///
+/// 1. **Build phase** (via [update] + [performRebuild] overrides): Pushes
+///    session onto [DependencyTracker._stack] during element updates and
+///    rebuilds, including recursive child updates. This ensures that
+///    [SliverMultiBoxAdaptorElement.performRebuild] (which rebuilds
+///    existing sliver children via itemBuilder) captures property
+///    accesses in the correct session — even with multiple Bind.viewModel
+///    widgets in the tree.
+///
+/// 2. **Layout phase** (via [_contextStack] on mount/unmount): Registers
+///    on a context stack for layout-phase deferred callback fallback
+///    (e.g. new items created via [invokeLayoutCallback]).
 class _TrackingContextElement extends InheritedElement {
   _TrackingContextElement(_TrackingContextWidget super.widget);
 
   @override
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
-    // Capture context immediately after mounting
-    DependencyTracker.setCurrentContext(this);
+    DependencyTracker._contextStack.add(this);
   }
 
   @override
   void unmount() {
-    // Clear context before unmounting
-    DependencyTracker.setCurrentContext(null);
+    DependencyTracker._contextStack.remove(this);
     super.unmount();
+  }
+
+  @override
+  void update(_TrackingContextWidget newWidget) {
+    // Push session onto stack during update. When the parent rebuilds
+    // (e.g. BindViewModelState.build), it creates a new _TrackingContextWidget
+    // with a new session. The super.update() call triggers updateChild on
+    // descendant elements, which may call SliverMultiBoxAdaptorElement.update()
+    // → performRebuild() → itemBuilder. Wrapping this in the session push
+    // ensures those itemBuilder accesses are captured correctly.
+    final session = newWidget.session;
+    DependencyTracker._stack.add(session);
+    try {
+      super.update(newWidget);
+    } finally {
+      DependencyTracker._stack.removeLast();
+    }
+  }
+
+  @override
+  void performRebuild() {
+    // Push session onto stack during initial build (mount).
+    // This covers the first frame where the element is newly created
+    // and performRebuild is called to build descendant elements.
+    final session = (widget as _TrackingContextWidget).session;
+    DependencyTracker._stack.add(session);
+    try {
+      super.performRebuild();
+    } finally {
+      DependencyTracker._stack.removeLast();
+    }
+  }
+}
+
+/// Auto-detecting layout wrapper that inserts a [_BoxTrackingLayout]
+/// (RenderProxyBox) in box contexts to capture layout-phase property
+/// accesses during the initial build.
+///
+/// In sliver contexts (where inserting a RenderProxyBox would cause a
+/// type mismatch), the wrapper is skipped and the [_contextStack]
+/// fallback handles layout-phase tracking.
+///
+/// The RenderProxyBox approach works for the initial build because the
+/// entire render tree is dirty and layout flows top-down through the
+/// parent chain (including through relayout boundaries like RenderViewport).
+/// For subsequent rebuilds, the [_TrackingContextElement.update] override
+/// captures build-phase accesses instead.
+class _TrackingLayoutWidget extends StatelessWidget {
+  final _TrackingSession session;
+  final Widget child;
+
+  const _TrackingLayoutWidget({
+    required this.session,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // In sliver context, skip box wrapping — the _contextStack fallback
+    // handles layout-phase tracking for sliver scenarios.
+    if (_isInSliverContext(context)) {
+      return child;
+    }
+    return _BoxTrackingLayout(session: session, child: child);
+  }
+
+  /// Detects whether this widget is in a context that expects sliver children.
+  /// If so, inserting a RenderProxyBox (a RenderBox) would cause a type error.
+  static bool _isInSliverContext(BuildContext context) {
+    final parent =
+        context.findAncestorRenderObjectOfType<RenderObject>();
+    if (parent == null) return false;
+
+    // RenderViewport is a RenderBox whose children must be RenderSlivers
+    if (parent is RenderViewport) return true;
+
+    // RenderSliver subtypes: some expect sliver children, some expect box.
+    // RenderSliverMultiBoxAdaptor (SliverList, SliverGrid, etc.) has box
+    // children — box wrapper is safe there. For all other RenderSliver
+    // subtypes (SliverPadding, SliverOpacity, etc.), assume sliver children
+    // and skip the box wrapper. This is the safer default: skipping the
+    // wrapper just loses the layout-phase optimization (falling back to
+    // _contextStack), while inserting it incorrectly would crash.
+    if (parent is RenderSliver && parent is! RenderSliverMultiBoxAdaptor) {
+      return true;
+    }
+
+    return false;
+  }
+}
+
+/// RenderObjectWidget that creates a [_BoxTrackingRenderBox] to push the
+/// tracking session during [performLayout]. This captures property accesses
+/// from deferred callbacks (itemBuilder, separatorBuilder) that execute
+/// during the layout phase of the initial build.
+class _BoxTrackingLayout extends SingleChildRenderObjectWidget {
+  final _TrackingSession session;
+
+  const _BoxTrackingLayout({
+    required this.session,
+    required Widget child,
+  }) : super(child: child);
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _BoxTrackingRenderBox(session);
+  }
+
+  @override
+  void updateRenderObject(
+      BuildContext context, _BoxTrackingRenderBox renderObject) {
+    renderObject.session = session;
+  }
+}
+
+/// RenderProxyBox that pushes the tracking session onto the stack during
+/// [performLayout]. When the child render tree is laid out (including
+/// through RenderViewport → SliverList), any property accesses from
+/// itemBuilder callbacks are captured in the correct session.
+///
+/// This is effective for the initial build because the entire render tree
+/// is dirty and layout flows synchronously from parent to child through
+/// all relayout boundaries. For subsequent builds, RenderViewport may
+/// be laid out independently (since it IS a relayout boundary), so this
+/// render object's [performLayout] may not be called — the
+/// [_TrackingContextElement.update] override handles that case instead.
+class _BoxTrackingRenderBox extends RenderProxyBox {
+  _TrackingSession session;
+
+  _BoxTrackingRenderBox(this.session);
+
+  @override
+  void performLayout() {
+    DependencyTracker._stack.add(session);
+    try {
+      super.performLayout();
+    } finally {
+      DependencyTracker._stack.removeLast();
+    }
   }
 }

--- a/src/lib/src/ui/bind_viewmodel_widget.dart
+++ b/src/lib/src/ui/bind_viewmodel_widget.dart
@@ -292,7 +292,11 @@ class BindViewModel2<TViewModel1 extends ObservableObject,
   const BindViewModel2({
     super.key,
     required this.builder,
-  });
+  }) : assert(
+         TViewModel1 != TViewModel2,
+         'BindViewModel2 requires two different ViewModel types. '
+         'Use BindViewModel instead for a single ViewModel type.',
+       );
 
   @override
   State<BindViewModel2<TViewModel1, TViewModel2>> createState() =>
@@ -430,7 +434,13 @@ class BindViewModel3<
   const BindViewModel3({
     super.key,
     required this.builder,
-  });
+  }) : assert(
+         TViewModel1 != TViewModel2 &&
+             TViewModel1 != TViewModel3 &&
+             TViewModel2 != TViewModel3,
+         'BindViewModel3 requires three different ViewModel types. '
+         'Each type parameter must be unique.',
+       );
 
   @override
   State<BindViewModel3<TViewModel1, TViewModel2, TViewModel3>> createState() =>
@@ -575,7 +585,16 @@ class BindViewModel4<
   const BindViewModel4({
     super.key,
     required this.builder,
-  });
+  }) : assert(
+         TViewModel1 != TViewModel2 &&
+             TViewModel1 != TViewModel3 &&
+             TViewModel1 != TViewModel4 &&
+             TViewModel2 != TViewModel3 &&
+             TViewModel2 != TViewModel4 &&
+             TViewModel3 != TViewModel4,
+         'BindViewModel4 requires four different ViewModel types. '
+         'Each type parameter must be unique.',
+       );
 
   @override
   State<BindViewModel4<TViewModel1, TViewModel2, TViewModel3, TViewModel4>>

--- a/src/lib/src/ui/bind_viewmodel_widget.dart
+++ b/src/lib/src/ui/bind_viewmodel_widget.dart
@@ -293,10 +293,10 @@ class BindViewModel2<TViewModel1 extends ObservableObject,
     super.key,
     required this.builder,
   }) : assert(
-         TViewModel1 != TViewModel2,
-         'BindViewModel2 requires two different ViewModel types. '
-         'Use BindViewModel instead for a single ViewModel type.',
-       );
+          TViewModel1 != TViewModel2,
+          'BindViewModel2 requires two different ViewModel types. '
+          'Use BindViewModel instead for a single ViewModel type.',
+        );
 
   @override
   State<BindViewModel2<TViewModel1, TViewModel2>> createState() =>
@@ -435,12 +435,12 @@ class BindViewModel3<
     super.key,
     required this.builder,
   }) : assert(
-         TViewModel1 != TViewModel2 &&
-             TViewModel1 != TViewModel3 &&
-             TViewModel2 != TViewModel3,
-         'BindViewModel3 requires three different ViewModel types. '
-         'Each type parameter must be unique.',
-       );
+          TViewModel1 != TViewModel2 &&
+              TViewModel1 != TViewModel3 &&
+              TViewModel2 != TViewModel3,
+          'BindViewModel3 requires three different ViewModel types. '
+          'Each type parameter must be unique.',
+        );
 
   @override
   State<BindViewModel3<TViewModel1, TViewModel2, TViewModel3>> createState() =>
@@ -586,15 +586,15 @@ class BindViewModel4<
     super.key,
     required this.builder,
   }) : assert(
-         TViewModel1 != TViewModel2 &&
-             TViewModel1 != TViewModel3 &&
-             TViewModel1 != TViewModel4 &&
-             TViewModel2 != TViewModel3 &&
-             TViewModel2 != TViewModel4 &&
-             TViewModel3 != TViewModel4,
-         'BindViewModel4 requires four different ViewModel types. '
-         'Each type parameter must be unique.',
-       );
+          TViewModel1 != TViewModel2 &&
+              TViewModel1 != TViewModel3 &&
+              TViewModel1 != TViewModel4 &&
+              TViewModel2 != TViewModel3 &&
+              TViewModel2 != TViewModel4 &&
+              TViewModel3 != TViewModel4,
+          'BindViewModel4 requires four different ViewModel types. '
+          'Each type parameter must be unique.',
+        );
 
   @override
   State<BindViewModel4<TViewModel1, TViewModel2, TViewModel3, TViewModel4>>

--- a/src/lib/src/ui/bind_widget.dart
+++ b/src/lib/src/ui/bind_widget.dart
@@ -161,6 +161,11 @@ class Bind<TViewModel extends ObservableObject, TValue> extends StatefulWidget {
             BuildContext context, TViewModel1 vm1, TViewModel2 vm2)
         builder,
   }) {
+    assert(
+      TViewModel1 != TViewModel2,
+      'Bind.viewModel2 requires two different ViewModel types. '
+      'Use Bind.viewModel instead for a single ViewModel type.',
+    );
     return BindViewModel2<TViewModel1, TViewModel2>(
       key: key,
       builder: builder,
@@ -196,6 +201,13 @@ class Bind<TViewModel extends ObservableObject, TValue> extends StatefulWidget {
       TViewModel3 vm3,
     ) builder,
   }) {
+    assert(
+      TViewModel1 != TViewModel2 &&
+          TViewModel1 != TViewModel3 &&
+          TViewModel2 != TViewModel3,
+      'Bind.viewModel3 requires three different ViewModel types. '
+      'Each type parameter must be unique.',
+    );
     return BindViewModel3<TViewModel1, TViewModel2, TViewModel3>(
       key: key,
       builder: builder,
@@ -235,6 +247,16 @@ class Bind<TViewModel extends ObservableObject, TValue> extends StatefulWidget {
       TViewModel4 vm4,
     ) builder,
   }) {
+    assert(
+      TViewModel1 != TViewModel2 &&
+          TViewModel1 != TViewModel3 &&
+          TViewModel1 != TViewModel4 &&
+          TViewModel2 != TViewModel3 &&
+          TViewModel2 != TViewModel4 &&
+          TViewModel3 != TViewModel4,
+      'Bind.viewModel4 requires four different ViewModel types. '
+      'Each type parameter must be unique.',
+    );
     return BindViewModel4<TViewModel1, TViewModel2, TViewModel3, TViewModel4>(
       key: key,
       builder: builder,
@@ -381,23 +403,31 @@ class _BindState<TViewModel extends ObservableObject, TValue>
 
   @override
   Widget build(BuildContext context) {
-    // Extract value and update callback based on binding type
-    if (_selected is ObservableProperty<TValue>) {
-      // Two-way binding
-      final property = _selected as ObservableProperty<TValue>;
-      return widget.builder(
-        context,
-        property.value,
-        (newValue) => property.value = newValue,
-      );
-    } else if (_selected is ComputedProperty<TValue>) {
-      // One-way binding with ComputedProperty
-      final computed = _selected as ComputedProperty<TValue>;
-      return widget.builder(context, computed.value, null);
-    } else {
-      // One-way binding
-      final value = _selected as TValue;
-      return widget.builder(context, value, null);
-    }
+    // Wrap in track() to create an isolated session. This prevents
+    // property.value accesses from leaking into ancestor Bind.viewModel
+    // tracking sessions (which push their session during element updates).
+    // The session result is discarded — Bind manages its own subscriptions
+    // via propertyChanged in didChangeDependencies.
+    final (result, _, _) = DependencyTracker.track(() {
+      // Extract value and update callback based on binding type
+      if (_selected is ObservableProperty<TValue>) {
+        // Two-way binding
+        final property = _selected as ObservableProperty<TValue>;
+        return widget.builder(
+          context,
+          property.value,
+          (newValue) => property.value = newValue,
+        );
+      } else if (_selected is ComputedProperty<TValue>) {
+        // One-way binding with ComputedProperty
+        final computed = _selected as ComputedProperty<TValue>;
+        return widget.builder(context, computed.value, null);
+      } else {
+        // One-way binding
+        final value = _selected as TValue;
+        return widget.builder(context, value, null);
+      }
+    });
+    return result;
   }
 }

--- a/src/lib/src/ui/command_widget.dart
+++ b/src/lib/src/ui/command_widget.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import '../core/observable.dart';
 import '../core/command.dart';
+import '../internal/dependency_tracker.dart';
 import '../locator/fairy_resolver.dart';
 
 /// A widget that binds a [RelayCommand] or [AsyncRelayCommand] to UI.
@@ -217,30 +217,36 @@ class _CommandState<TViewModel extends ObservableObject>
 
   @override
   Widget build(BuildContext context) {
-    // Extract execute, canExecute, and isRunning from command
-    final VoidCallback execute;
-    final bool canExecute;
-    final bool isRunning;
+    // Wrap in track() to create an isolated session. This prevents
+    // command property accesses (canExecute, isRunning) from leaking
+    // into ancestor Bind.viewModel tracking sessions.
+    final (result, _, _) = DependencyTracker.track(() {
+      // Extract execute, canExecute, and isRunning from command
+      final VoidCallback execute;
+      final bool canExecute;
+      final bool isRunning;
 
-    if (_commandInstance is RelayCommand) {
-      final cmd = _commandInstance as RelayCommand;
-      execute = cmd.execute;
-      canExecute = cmd.canExecute;
-      isRunning = false; // Sync commands never run asynchronously
-    } else if (_commandInstance is AsyncRelayCommand) {
-      final cmd = _commandInstance as AsyncRelayCommand;
-      execute = cmd.execute;
-      canExecute = cmd.canExecute;
-      isRunning = cmd.isRunning; // Actual running state for async commands
-    } else {
-      throw StateError(
-        'Command<$TViewModel> selector must return a RelayCommand or AsyncRelayCommand. '
-        'Got: ${_commandInstance.runtimeType}. '
-        'For parameterized commands, use Command.param<$TViewModel, TParam>() instead.',
-      );
-    }
+      if (_commandInstance is RelayCommand) {
+        final cmd = _commandInstance as RelayCommand;
+        execute = cmd.execute;
+        canExecute = cmd.canExecute;
+        isRunning = false; // Sync commands never run asynchronously
+      } else if (_commandInstance is AsyncRelayCommand) {
+        final cmd = _commandInstance as AsyncRelayCommand;
+        execute = cmd.execute;
+        canExecute = cmd.canExecute;
+        isRunning = cmd.isRunning; // Actual running state for async commands
+      } else {
+        throw StateError(
+          'Command<$TViewModel> selector must return a RelayCommand or AsyncRelayCommand. '
+          'Got: ${_commandInstance.runtimeType}. '
+          'For parameterized commands, use Command.param<$TViewModel, TParam>() instead.',
+        );
+      }
 
-    return widget.builder(context, execute, canExecute, isRunning);
+      return widget.builder(context, execute, canExecute, isRunning);
+    });
+    return result;
   }
 }
 
@@ -330,29 +336,35 @@ class _CommandWithParamState<TViewModel extends ObservableObject, TParam>
 
   @override
   Widget build(BuildContext context) {
-    final void Function(TParam) execute;
-    final bool Function(TParam) canExecute;
-    final bool isRunning;
+    // Wrap in track() to create an isolated session. This prevents
+    // command property accesses (canExecute, isRunning) from leaking
+    // into ancestor Bind.viewModel tracking sessions.
+    final (result, _, _) = DependencyTracker.track(() {
+      final void Function(TParam) execute;
+      final bool Function(TParam) canExecute;
+      final bool isRunning;
 
-    if (_commandInstance is RelayCommandWithParam<TParam>) {
-      final cmd = _commandInstance as RelayCommandWithParam<TParam>;
-      execute = cmd.execute;
-      canExecute = cmd.canExecute;
-      isRunning = false; // Sync commands never run asynchronously
-    } else if (_commandInstance is AsyncRelayCommandWithParam<TParam>) {
-      final cmd = _commandInstance as AsyncRelayCommandWithParam<TParam>;
-      execute = cmd.execute;
-      canExecute = cmd.canExecute;
-      isRunning = cmd.isRunning; // Actual running state for async commands
-    } else {
-      throw StateError(
-        'Command.param<$TViewModel, $TParam> selector must return a '
-        'RelayCommandWithParam<$TParam> or AsyncRelayCommandWithParam<$TParam>. '
-        'Got: ${_commandInstance.runtimeType}. '
-        'For non-parameterized commands, use Command<$TViewModel>() instead.',
-      );
-    }
+      if (_commandInstance is RelayCommandWithParam<TParam>) {
+        final cmd = _commandInstance as RelayCommandWithParam<TParam>;
+        execute = cmd.execute;
+        canExecute = cmd.canExecute;
+        isRunning = false; // Sync commands never run asynchronously
+      } else if (_commandInstance is AsyncRelayCommandWithParam<TParam>) {
+        final cmd = _commandInstance as AsyncRelayCommandWithParam<TParam>;
+        execute = cmd.execute;
+        canExecute = cmd.canExecute;
+        isRunning = cmd.isRunning; // Actual running state for async commands
+      } else {
+        throw StateError(
+          'Command.param<$TViewModel, $TParam> selector must return a '
+          'RelayCommandWithParam<$TParam> or AsyncRelayCommandWithParam<$TParam>. '
+          'Got: ${_commandInstance.runtimeType}. '
+          'For non-parameterized commands, use Command<$TViewModel>() instead.',
+        );
+      }
 
-    return widget.builder(context, execute, canExecute, isRunning);
+      return widget.builder(context, execute, canExecute, isRunning);
+    });
+    return result;
   }
 }

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fairy
 description: A lightweight MVVM framework for Flutter with strongly-typed, reactive data binding state management library, Mainly focused on simplicity and ease of use.
-version: 3.0.0+1
+version: 3.0.1
 repository: https://github.com/Circuids/Fairy
 issue_tracker: https://github.com/Circuids/Fairy/issues
 homepage: https://github.com/Circuids/Fairy

--- a/src/test/ui/bind_viewmodel_context_tracking_test.dart
+++ b/src/test/ui/bind_viewmodel_context_tracking_test.dart
@@ -38,8 +38,8 @@ class _ViewModelB extends ObservableObject {
 // ─────────────────────────────────────────────────────────────
 
 void main() {
-  group(
-      'Bind.viewModel — _currentContext cross-widget tracking correctness', () {
+  group('Bind.viewModel — _currentContext cross-widget tracking correctness',
+      () {
     // ───────────────────────────────────────────────────────
     // Test 1 (Baseline): Single widget with lazy builder
     // ───────────────────────────────────────────────────────
@@ -253,7 +253,8 @@ void main() {
         expect(
           widgetBBuildCount,
           1,
-          reason: 'Widget B should NOT rebuild — vmA.marker is unrelated to VmB',
+          reason:
+              'Widget B should NOT rebuild — vmA.marker is unrelated to VmB',
         );
       },
     );

--- a/src/test/ui/bind_viewmodel_context_tracking_test.dart
+++ b/src/test/ui/bind_viewmodel_context_tracking_test.dart
@@ -1,0 +1,429 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fairy/src/core/observable.dart';
+import 'package:fairy/src/locator/fairy_scope.dart';
+import 'package:fairy/src/ui/bind_widget.dart';
+
+// ─────────────────────────────────────────────────────────────
+// Test ViewModels
+// ─────────────────────────────────────────────────────────────
+
+/// ViewModel with list items and a deferred-only property (highlight).
+/// Used by tests where two Bind.viewModel widgets share the same VM.
+class _SharedViewModel extends ObservableObject {
+  final items = ObservableProperty<List<String>>(['a', 'b', 'c']);
+  final highlight = ObservableProperty<String>('a');
+  final label = ObservableProperty<String>('hello');
+}
+
+/// ViewModel A for cross-type isolation tests.
+class _ViewModelA extends ObservableObject {
+  final items = ObservableProperty<List<String>>(['x', 'y']);
+  final marker = ObservableProperty<String>('x');
+}
+
+/// ViewModel B for cross-type isolation tests.
+class _ViewModelB extends ObservableObject {
+  final label = ObservableProperty<String>('initial');
+}
+
+// ─────────────────────────────────────────────────────────────
+// Tests: _currentContext cross-widget tracking corruption
+//
+// Bug: DependencyTracker._currentContext is a single global static.
+// When multiple Bind.viewModel widgets mount, the last one to mount
+// overwrites _currentContext. Deferred accesses (e.g. ListView.builder's
+// itemBuilder) from earlier-mounted widgets use the wrong session,
+// causing missed rebuilds.
+// ─────────────────────────────────────────────────────────────
+
+void main() {
+  group(
+      'Bind.viewModel — _currentContext cross-widget tracking correctness', () {
+    // ───────────────────────────────────────────────────────
+    // Test 1 (Baseline): Single widget with lazy builder
+    // ───────────────────────────────────────────────────────
+    testWidgets(
+      'Test 1 (Baseline): Single Bind.viewModel with lazy builder '
+      'tracks deferred-only property and rebuilds correctly',
+      (tester) async {
+        final vm = _SharedViewModel();
+        var buildCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_SharedViewModel>(
+                builder: (context, vm) {
+                  buildCount++;
+                  return ListView.builder(
+                    itemCount: vm.items.value.length,
+                    itemBuilder: (context, index) {
+                      // highlight is accessed ONLY here (deferred callback)
+                      // It is NOT accessed in the synchronous builder above
+                      final isHighlighted =
+                          vm.items.value[index] == vm.highlight.value;
+                      return Text(
+                        '${vm.items.value[index]}${isHighlighted ? " *" : ""}',
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(buildCount, 1);
+        expect(find.text('a *'), findsOneWidget);
+        expect(find.text('b'), findsOneWidget);
+        expect(find.text('c'), findsOneWidget);
+
+        // Change highlight — widget should rebuild via deferred tracking
+        vm.highlight.value = 'b';
+        await tester.pump();
+
+        expect(
+          buildCount,
+          2,
+          reason:
+              'Single widget should rebuild when deferred-only property changes',
+        );
+        expect(find.text('a'), findsOneWidget);
+        expect(find.text('b *'), findsOneWidget);
+        expect(find.text('c'), findsOneWidget);
+      },
+    );
+
+    // ───────────────────────────────────────────────────────
+    // Test 2: Two Bind.viewModel widgets (same VM type)
+    //   Widget A (first child, mounts first): lazy builder reading highlight
+    //   Widget B (second child, mounts second): direct Text
+    //   Bug: Widget B's mount overwrites _currentContext, so Widget A's
+    //   deferred highlight access goes to Widget B's session.
+    // ───────────────────────────────────────────────────────
+    testWidgets(
+      'Test 2: Two Bind.viewModel widgets (same VM) — deferred access in '
+      'first widget should be tracked by first widget, not second',
+      (tester) async {
+        final vm = _SharedViewModel();
+        var widgetABuildCount = 0;
+        var widgetBBuildCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Column(
+                children: [
+                  // Widget A — mounts FIRST, has lazy builder.
+                  // highlight is accessed ONLY in itemBuilder (deferred).
+                  Expanded(
+                    child: Bind.viewModel<_SharedViewModel>(
+                      builder: (context, vm) {
+                        widgetABuildCount++;
+                        return ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            final isHighlighted =
+                                vm.items.value[index] == vm.highlight.value;
+                            return Text(
+                              'A:${vm.items.value[index]}${isHighlighted ? " *" : ""}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  // Widget B — mounts SECOND, overwrites _currentContext.
+                  // Reads label directly (synchronous).
+                  Bind.viewModel<_SharedViewModel>(
+                    builder: (context, vm) {
+                      widgetBBuildCount++;
+                      return Text('B:${vm.label.value}');
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(widgetABuildCount, 1);
+        expect(widgetBBuildCount, 1);
+        expect(find.text('A:a *'), findsOneWidget);
+        expect(find.text('B:hello'), findsOneWidget);
+
+        // Change highlight —
+        //   Widget A SHOULD rebuild (reads highlight in deferred itemBuilder)
+        //   Widget B should NOT rebuild (doesn't access highlight at all)
+        vm.highlight.value = 'b';
+        await tester.pump();
+
+        expect(
+          widgetABuildCount,
+          2,
+          reason: 'Widget A should rebuild — highlight is accessed '
+              'in its deferred itemBuilder',
+        );
+        expect(find.text('A:a'), findsOneWidget);
+        expect(find.text('A:b *'), findsOneWidget);
+        expect(find.text('A:c'), findsOneWidget);
+
+        // Widget B must NOT have rebuilt (it doesn't access highlight)
+        expect(
+          widgetBBuildCount,
+          1,
+          reason: 'Widget B should NOT rebuild — it does not access highlight',
+        );
+      },
+    );
+
+    // ───────────────────────────────────────────────────────
+    // Test 3: Two Bind.viewModel widgets (different VM types)
+    //   Ensures deferred accesses don't cross-contaminate between VMs.
+    // ───────────────────────────────────────────────────────
+    testWidgets(
+      'Test 3: Two Bind.viewModel widgets (different VMs) — deferred access '
+      'in VmA should NOT leak to VmB tracking session',
+      (tester) async {
+        final vmA = _ViewModelA();
+        final vmB = _ViewModelB();
+        var widgetABuildCount = 0;
+        var widgetBBuildCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [
+                (_) => vmA,
+                (_) => vmB,
+              ],
+              child: Column(
+                children: [
+                  // Widget A — mounts FIRST, lazy builder accessing marker
+                  Expanded(
+                    child: Bind.viewModel<_ViewModelA>(
+                      builder: (context, vm) {
+                        widgetABuildCount++;
+                        return ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            // marker accessed ONLY here (deferred)
+                            final isMarked =
+                                vm.items.value[index] == vm.marker.value;
+                            return Text(
+                              'A:${vm.items.value[index]}${isMarked ? " !" : ""}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  // Widget B — mounts SECOND, reads its own label
+                  Bind.viewModel<_ViewModelB>(
+                    builder: (context, vm) {
+                      widgetBBuildCount++;
+                      return Text('B:${vm.label.value}');
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(widgetABuildCount, 1);
+        expect(widgetBBuildCount, 1);
+
+        // Change vmA.marker — Widget A should rebuild, Widget B should NOT
+        vmA.marker.value = 'y';
+        await tester.pump();
+
+        expect(
+          widgetABuildCount,
+          2,
+          reason: 'Widget A should rebuild when marker changes '
+              '(accessed in deferred itemBuilder)',
+        );
+        expect(find.text('A:x'), findsOneWidget);
+        expect(find.text('A:y !'), findsOneWidget);
+
+        expect(
+          widgetBBuildCount,
+          1,
+          reason: 'Widget B should NOT rebuild — vmA.marker is unrelated to VmB',
+        );
+      },
+    );
+
+    // ───────────────────────────────────────────────────────
+    // Test 4: Scaffold body + bottomNavigationBar
+    //   body mounts before bottomNavigationBar. Body has lazy builder
+    //   accessing highlight. Bottom reads highlight directly.
+    //   Both should rebuild when highlight changes.
+    // ───────────────────────────────────────────────────────
+    testWidgets(
+      'Test 4: Scaffold body + bottomNavigationBar — mount order '
+      'should not affect deferred tracking correctness',
+      (tester) async {
+        final vm = _SharedViewModel();
+        var bodyBuildCount = 0;
+        var bottomBuildCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Scaffold(
+                body: Bind.viewModel<_SharedViewModel>(
+                  builder: (context, vm) {
+                    bodyBuildCount++;
+                    return ListView.builder(
+                      itemCount: vm.items.value.length,
+                      itemBuilder: (context, index) {
+                        // highlight accessed ONLY in deferred itemBuilder
+                        final isHighlighted =
+                            vm.items.value[index] == vm.highlight.value;
+                        return Text(
+                          'Body:${vm.items.value[index]}${isHighlighted ? " *" : ""}',
+                        );
+                      },
+                    );
+                  },
+                ),
+                bottomNavigationBar: SizedBox(
+                  height: 56,
+                  child: Bind.viewModel<_SharedViewModel>(
+                    builder: (context, vm) {
+                      bottomBuildCount++;
+                      return Center(
+                        child: Text('Bottom:${vm.highlight.value}'),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        expect(bodyBuildCount, 1);
+        expect(bottomBuildCount, 1);
+        expect(find.text('Body:a *'), findsOneWidget);
+        expect(find.text('Bottom:a'), findsOneWidget);
+
+        // Change highlight — BOTH widgets should rebuild
+        //   Body: reads highlight in deferred itemBuilder
+        //   Bottom: reads highlight directly in builder
+        vm.highlight.value = 'c';
+        await tester.pump();
+
+        expect(
+          bodyBuildCount,
+          2,
+          reason: 'Body should rebuild — highlight accessed in '
+              'deferred itemBuilder',
+        );
+        expect(find.text('Body:c *'), findsOneWidget);
+
+        expect(
+          bottomBuildCount,
+          2,
+          reason: 'Bottom should rebuild — highlight accessed directly',
+        );
+        expect(find.text('Bottom:c'), findsOneWidget);
+      },
+    );
+
+    // ───────────────────────────────────────────────────────
+    // Test 5: Three Bind.viewModel widgets — middle has lazy builder
+    //   Widget 1: reads label (direct)
+    //   Widget 2: reads highlight in lazy builder ONLY
+    //   Widget 3: reads label (direct)
+    //   Changing highlight should rebuild only Widget 2.
+    // ───────────────────────────────────────────────────────
+    testWidgets(
+      'Test 5: Three Bind.viewModel widgets — only the widget with '
+      'deferred access to changed property should rebuild',
+      (tester) async {
+        final vm = _SharedViewModel();
+        var widget1BuildCount = 0;
+        var widget2BuildCount = 0;
+        var widget3BuildCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Column(
+                children: [
+                  // Widget 1: reads label directly
+                  Bind.viewModel<_SharedViewModel>(
+                    builder: (context, vm) {
+                      widget1BuildCount++;
+                      return Text('W1:${vm.label.value}');
+                    },
+                  ),
+                  // Widget 2: reads highlight ONLY in lazy builder
+                  Expanded(
+                    child: Bind.viewModel<_SharedViewModel>(
+                      builder: (context, vm) {
+                        widget2BuildCount++;
+                        return ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            final isHighlighted =
+                                vm.items.value[index] == vm.highlight.value;
+                            return Text(
+                              'W2:${vm.items.value[index]}${isHighlighted ? " *" : ""}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  // Widget 3: reads label directly
+                  Bind.viewModel<_SharedViewModel>(
+                    builder: (context, vm) {
+                      widget3BuildCount++;
+                      return Text('W3:${vm.label.value}');
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(widget1BuildCount, 1);
+        expect(widget2BuildCount, 1);
+        expect(widget3BuildCount, 1);
+
+        // Change highlight — only Widget 2 should rebuild
+        vm.highlight.value = 'b';
+        await tester.pump();
+
+        expect(
+          widget2BuildCount,
+          2,
+          reason: 'Widget 2 should rebuild — highlight accessed '
+              'in its deferred itemBuilder',
+        );
+        expect(find.text('W2:b *'), findsOneWidget);
+
+        expect(
+          widget1BuildCount,
+          1,
+          reason: 'Widget 1 should NOT rebuild — does not access highlight',
+        );
+        expect(
+          widget3BuildCount,
+          1,
+          reason: 'Widget 3 should NOT rebuild — does not access highlight',
+        );
+      },
+    );
+  });
+}

--- a/src/test/ui/bind_viewmodel_duplicate_type_test.dart
+++ b/src/test/ui/bind_viewmodel_duplicate_type_test.dart
@@ -178,7 +178,8 @@ void main() {
               viewModels: [(_) => vmA, (_) => vmB, (_) => vmC],
               child: Bind.viewModel3<_ViewModelA, _ViewModelB, _ViewModelC>(
                 builder: (context, a, b, c) {
-                  return Text('${a.name.value} ${b.name.value} ${c.name.value}');
+                  return Text(
+                      '${a.name.value} ${b.name.value} ${c.name.value}');
                 },
               ),
             ),
@@ -204,8 +205,7 @@ void main() {
                 expect(
                   () => Bind.viewModel4<_ViewModelA, _ViewModelA, _ViewModelC,
                       _ViewModelD>(
-                    builder: (context, a1, a2, c, d) =>
-                        const SizedBox.shrink(),
+                    builder: (context, a1, a2, c, d) => const SizedBox.shrink(),
                   ),
                   throwsAssertionError,
                 );
@@ -227,8 +227,7 @@ void main() {
                 expect(
                   () => Bind.viewModel4<_ViewModelA, _ViewModelB, _ViewModelA,
                       _ViewModelD>(
-                    builder: (context, a1, b, a2, d) =>
-                        const SizedBox.shrink(),
+                    builder: (context, a1, b, a2, d) => const SizedBox.shrink(),
                   ),
                   throwsAssertionError,
                 );
@@ -250,8 +249,7 @@ void main() {
                 expect(
                   () => Bind.viewModel4<_ViewModelA, _ViewModelB, _ViewModelC,
                       _ViewModelA>(
-                    builder: (context, a1, b, c, a2) =>
-                        const SizedBox.shrink(),
+                    builder: (context, a1, b, c, a2) => const SizedBox.shrink(),
                   ),
                   throwsAssertionError,
                 );
@@ -273,8 +271,7 @@ void main() {
                 expect(
                   () => Bind.viewModel4<_ViewModelA, _ViewModelB, _ViewModelB,
                       _ViewModelD>(
-                    builder: (context, a, b1, b2, d) =>
-                        const SizedBox.shrink(),
+                    builder: (context, a, b1, b2, d) => const SizedBox.shrink(),
                   ),
                   throwsAssertionError,
                 );
@@ -296,8 +293,7 @@ void main() {
                 expect(
                   () => Bind.viewModel4<_ViewModelA, _ViewModelB, _ViewModelC,
                       _ViewModelC>(
-                    builder: (context, a, b, c1, c2) =>
-                        const SizedBox.shrink(),
+                    builder: (context, a, b, c1, c2) => const SizedBox.shrink(),
                   ),
                   throwsAssertionError,
                 );

--- a/src/test/ui/bind_viewmodel_duplicate_type_test.dart
+++ b/src/test/ui/bind_viewmodel_duplicate_type_test.dart
@@ -1,0 +1,405 @@
+import 'package:fairy/fairy.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ───────────────────────────────────────────────────────────────────────────
+// ViewModels for testing
+// ───────────────────────────────────────────────────────────────────────────
+class _ViewModelA extends ObservableObject {
+  late final name = ObservableProperty<String>('A');
+}
+
+class _ViewModelB extends ObservableObject {
+  late final name = ObservableProperty<String>('B');
+}
+
+class _ViewModelC extends ObservableObject {
+  late final name = ObservableProperty<String>('C');
+}
+
+class _ViewModelD extends ObservableObject {
+  late final name = ObservableProperty<String>('D');
+}
+
+void main() {
+  // ─────────────────────────────────────────────────────────────────────────
+  // Bind.viewModel2 — duplicate type prevention
+  // ─────────────────────────────────────────────────────────────────────────
+  group('Bind.viewModel2 — duplicate type assertion', () {
+    testWidgets(
+      'throws AssertionError when both type parameters are the same',
+      (tester) async {
+        final vm = _ViewModelA();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vm],
+              child: Builder(
+                builder: (context) {
+                  // Should throw assertion error
+                  expect(
+                    () => Bind.viewModel2<_ViewModelA, _ViewModelA>(
+                      builder: (context, a1, a2) => Text('${a1.name.value}'),
+                    ),
+                    throwsAssertionError,
+                  );
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'does NOT throw when type parameters are different',
+      (tester) async {
+        final vmA = _ViewModelA();
+        final vmB = _ViewModelB();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB],
+              child: Bind.viewModel2<_ViewModelA, _ViewModelB>(
+                builder: (context, a, b) {
+                  return Text('${a.name.value} ${b.name.value}');
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('A B'), findsOneWidget);
+      },
+    );
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Bind.viewModel3 — duplicate type prevention
+  // ─────────────────────────────────────────────────────────────────────────
+  group('Bind.viewModel3 — duplicate type assertion', () {
+    testWidgets(
+      'throws when first and second types are the same',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                expect(
+                  () => Bind.viewModel3<_ViewModelA, _ViewModelA, _ViewModelC>(
+                    builder: (context, a1, a2, c) => const SizedBox.shrink(),
+                  ),
+                  throwsAssertionError,
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'throws when first and third types are the same',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                expect(
+                  () => Bind.viewModel3<_ViewModelA, _ViewModelB, _ViewModelA>(
+                    builder: (context, a1, b, a2) => const SizedBox.shrink(),
+                  ),
+                  throwsAssertionError,
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'throws when second and third types are the same',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                expect(
+                  () => Bind.viewModel3<_ViewModelA, _ViewModelB, _ViewModelB>(
+                    builder: (context, a, b1, b2) => const SizedBox.shrink(),
+                  ),
+                  throwsAssertionError,
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'throws when all three types are the same',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                expect(
+                  () => Bind.viewModel3<_ViewModelA, _ViewModelA, _ViewModelA>(
+                    builder: (context, a1, a2, a3) => const SizedBox.shrink(),
+                  ),
+                  throwsAssertionError,
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'does NOT throw when all three types are different',
+      (tester) async {
+        final vmA = _ViewModelA();
+        final vmB = _ViewModelB();
+        final vmC = _ViewModelC();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB, (_) => vmC],
+              child: Bind.viewModel3<_ViewModelA, _ViewModelB, _ViewModelC>(
+                builder: (context, a, b, c) {
+                  return Text('${a.name.value} ${b.name.value} ${c.name.value}');
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('A B C'), findsOneWidget);
+      },
+    );
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Bind.viewModel4 — duplicate type prevention
+  // ─────────────────────────────────────────────────────────────────────────
+  group('Bind.viewModel4 — duplicate type assertion', () {
+    testWidgets(
+      'throws when first and second types are the same',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                expect(
+                  () => Bind.viewModel4<_ViewModelA, _ViewModelA, _ViewModelC,
+                      _ViewModelD>(
+                    builder: (context, a1, a2, c, d) =>
+                        const SizedBox.shrink(),
+                  ),
+                  throwsAssertionError,
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'throws when first and third types are the same',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                expect(
+                  () => Bind.viewModel4<_ViewModelA, _ViewModelB, _ViewModelA,
+                      _ViewModelD>(
+                    builder: (context, a1, b, a2, d) =>
+                        const SizedBox.shrink(),
+                  ),
+                  throwsAssertionError,
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'throws when first and fourth types are the same',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                expect(
+                  () => Bind.viewModel4<_ViewModelA, _ViewModelB, _ViewModelC,
+                      _ViewModelA>(
+                    builder: (context, a1, b, c, a2) =>
+                        const SizedBox.shrink(),
+                  ),
+                  throwsAssertionError,
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'throws when second and third types are the same',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                expect(
+                  () => Bind.viewModel4<_ViewModelA, _ViewModelB, _ViewModelB,
+                      _ViewModelD>(
+                    builder: (context, a, b1, b2, d) =>
+                        const SizedBox.shrink(),
+                  ),
+                  throwsAssertionError,
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'throws when third and fourth types are the same',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                expect(
+                  () => Bind.viewModel4<_ViewModelA, _ViewModelB, _ViewModelC,
+                      _ViewModelC>(
+                    builder: (context, a, b, c1, c2) =>
+                        const SizedBox.shrink(),
+                  ),
+                  throwsAssertionError,
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'throws when all four types are the same',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                expect(
+                  () => Bind.viewModel4<_ViewModelA, _ViewModelA, _ViewModelA,
+                      _ViewModelA>(
+                    builder: (context, a1, a2, a3, a4) =>
+                        const SizedBox.shrink(),
+                  ),
+                  throwsAssertionError,
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'does NOT throw when all four types are different',
+      (tester) async {
+        final vmA = _ViewModelA();
+        final vmB = _ViewModelB();
+        final vmC = _ViewModelC();
+        final vmD = _ViewModelD();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB, (_) => vmC, (_) => vmD],
+              child: Bind.viewModel4<_ViewModelA, _ViewModelB, _ViewModelC,
+                  _ViewModelD>(
+                builder: (context, a, b, c, d) {
+                  return Text(
+                    '${a.name.value} ${b.name.value} ${c.name.value} ${d.name.value}',
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('A B C D'), findsOneWidget);
+      },
+    );
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Direct constructor usage (BindViewModel2/3/4) — same assertions
+  // ─────────────────────────────────────────────────────────────────────────
+  group('Direct BindViewModel constructors — duplicate type assertion', () {
+    testWidgets(
+      'BindViewModel2 throws when types are the same',
+      (tester) async {
+        expect(
+          () => BindViewModel2<_ViewModelA, _ViewModelA>(
+            builder: (context, a1, a2) => const SizedBox.shrink(),
+          ),
+          throwsAssertionError,
+        );
+      },
+    );
+
+    testWidgets(
+      'BindViewModel3 throws when any two types are the same',
+      (tester) async {
+        expect(
+          () => BindViewModel3<_ViewModelA, _ViewModelB, _ViewModelA>(
+            builder: (context, a1, b, a2) => const SizedBox.shrink(),
+          ),
+          throwsAssertionError,
+        );
+      },
+    );
+
+    testWidgets(
+      'BindViewModel4 throws when any two types are the same',
+      (tester) async {
+        expect(
+          () => BindViewModel4<_ViewModelA, _ViewModelB, _ViewModelC,
+              _ViewModelB>(
+            builder: (context, a, b1, c, b2) => const SizedBox.shrink(),
+          ),
+          throwsAssertionError,
+        );
+      },
+    );
+  });
+}

--- a/src/test/ui/dependency_tracker_edge_cases_test.dart
+++ b/src/test/ui/dependency_tracker_edge_cases_test.dart
@@ -407,19 +407,15 @@ void main() {
         vm.highlight.value = 'b';
         await tester.pump();
 
-        expect(buildsA, 2,
-            reason: 'A reads highlight in deferred builder');
-        expect(buildsB, 1,
-            reason: 'B does NOT read highlight');
+        expect(buildsA, 2, reason: 'A reads highlight in deferred builder');
+        expect(buildsB, 1, reason: 'B does NOT read highlight');
 
         // Change separator — only Widget B should rebuild
         vm.separator.value = '===';
         await tester.pump();
 
-        expect(buildsA, 2,
-            reason: 'A does NOT read separator');
-        expect(buildsB, 2,
-            reason: 'B reads separator in deferred builder');
+        expect(buildsA, 2, reason: 'A does NOT read separator');
+        expect(buildsB, 2, reason: 'B reads separator in deferred builder');
       },
     );
 
@@ -711,8 +707,7 @@ void main() {
                           cmdBuilds++;
                           return ElevatedButton(
                             onPressed: canExecute ? execute : null,
-                            child:
-                                Text('Can: $canExecute Running: $isRunning'),
+                            child: Text('Can: $canExecute Running: $isRunning'),
                           );
                         },
                       ),
@@ -830,8 +825,7 @@ void main() {
                     return ListView.builder(
                       itemCount: vm.items.value.length,
                       itemBuilder: (context, index) {
-                        final isM =
-                            vm.items.value[index] == vm.marker.value;
+                        final isM = vm.items.value[index] == vm.marker.value;
                         return Text(
                           '${vm.items.value[index]}${isM ? " *" : ""}',
                         );
@@ -1058,8 +1052,7 @@ void main() {
                   return ListView.builder(
                     itemCount: vm.items.value.length,
                     itemBuilder: (context, index) {
-                      final isH =
-                          vm.items.value[index] == vm.highlight.value;
+                      final isH = vm.items.value[index] == vm.highlight.value;
                       return Text(
                         '${vm.items.value[index]}${isH ? " *" : ""}',
                       );
@@ -1269,9 +1262,12 @@ void main() {
         final savedMiddle2 = middleBuilds;
         vm.highlight.value = 'c';
         await tester.pump();
-        expect(outerBuilds, savedOuter2, reason: 'Outer does NOT read highlight');
-        expect(middleBuilds, savedMiddle2, reason: 'Middle does NOT read highlight');
-        expect(innerBuilds, savedInner + 2, // +1 from separator change, +1 from highlight
+        expect(outerBuilds, savedOuter2,
+            reason: 'Outer does NOT read highlight');
+        expect(middleBuilds, savedMiddle2,
+            reason: 'Middle does NOT read highlight');
+        expect(innerBuilds,
+            savedInner + 2, // +1 from separator change, +1 from highlight
             reason: 'Inner reads highlight in deferred builder');
       },
     );
@@ -1464,8 +1460,8 @@ void main() {
                   return Column(
                     children: [
                       ElevatedButton(
-                        onPressed: () => setState2(
-                            () => currentKey = const ValueKey('v2')),
+                        onPressed: () =>
+                            setState2(() => currentKey = const ValueKey('v2')),
                         child: const Text('Change Key'),
                       ),
                       Expanded(
@@ -1622,8 +1618,7 @@ void main() {
         vm.separator.value = '===';
         await tester.pump();
         expect(listBuilds, 2);
-        expect(siblingBuilds, 1,
-            reason: 'Sibling does NOT read separator');
+        expect(siblingBuilds, 1, reason: 'Sibling does NOT read separator');
 
         // Change label — only sibling rebuilds
         vm.label.value = 'new';
@@ -1660,8 +1655,7 @@ void main() {
                     return ListView.builder(
                       itemCount: vm.items.value.length,
                       itemBuilder: (context, index) {
-                        final isH =
-                            vm.items.value[index] == vm.highlight.value;
+                        final isH = vm.items.value[index] == vm.highlight.value;
                         return Text(
                           '${vm.items.value[index]}${isH ? " *" : ""}',
                         );

--- a/src/test/ui/dependency_tracker_edge_cases_test.dart
+++ b/src/test/ui/dependency_tracker_edge_cases_test.dart
@@ -1,0 +1,2507 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fairy/src/core/observable.dart';
+import 'package:fairy/src/core/command.dart';
+import 'package:fairy/src/locator/fairy_scope.dart';
+import 'package:fairy/src/ui/bind_widget.dart';
+import 'package:fairy/src/ui/command_widget.dart';
+
+// ============================================================================
+// ViewModels
+// ============================================================================
+
+class _ItemsViewModel extends ObservableObject {
+  final items = ObservableProperty<List<String>>(['a', 'b', 'c']);
+  final highlight = ObservableProperty<String>('a');
+  final separator = ObservableProperty<String>('---');
+  final label = ObservableProperty<String>('hello');
+  final counter = ObservableProperty<int>(0);
+}
+
+class _OtherViewModel extends ObservableObject {
+  final text = ObservableProperty<String>('other');
+}
+
+class _CommandViewModel extends ObservableObject {
+  final items = ObservableProperty<List<String>>(['x', 'y']);
+  final enabled = ObservableProperty<bool>(true);
+
+  late final RelayCommand doAction;
+  late final AsyncRelayCommand doAsync;
+
+  int actionCount = 0;
+
+  _CommandViewModel() {
+    doAction = RelayCommand(
+      () => actionCount++,
+      canExecute: () => enabled.value,
+    );
+    doAsync = AsyncRelayCommand(
+      () async {
+        await Future.delayed(const Duration(milliseconds: 50));
+        actionCount++;
+      },
+      canExecute: () => enabled.value,
+    );
+  }
+}
+
+class _ToggleViewModel extends ObservableObject {
+  final showList = ObservableProperty<bool>(true);
+  final items = ObservableProperty<List<String>>(['1', '2', '3']);
+  final marker = ObservableProperty<String>('1');
+}
+
+class _TabViewModel extends ObservableObject {
+  final selectedTab = ObservableProperty<int>(0);
+  final tabAItems = ObservableProperty<List<String>>(['A1', 'A2']);
+  final tabBItems = ObservableProperty<List<String>>(['B1', 'B2']);
+  final tabALabel = ObservableProperty<String>('Tab A');
+  final tabBLabel = ObservableProperty<String>('Tab B');
+}
+
+class _GrowingListViewModel extends ObservableObject {
+  final items = ObservableProperty<List<String>>([]);
+  final tag = ObservableProperty<String>('v1');
+}
+
+class _VmA extends ObservableObject {
+  final listItems = ObservableProperty<List<String>>(['a', 'b', 'c']);
+  final badge = ObservableProperty<String>('!');
+}
+
+class _VmB extends ObservableObject {
+  final prefix = ObservableProperty<String>('>>');
+  final count = ObservableProperty<int>(0);
+}
+
+class _VmC extends ObservableObject {
+  final sep = ObservableProperty<String>('|');
+  final flag = ObservableProperty<bool>(false);
+}
+
+class _VmD extends ObservableObject {
+  final suffix = ObservableProperty<String>('.');
+  final score = ObservableProperty<int>(100);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+void main() {
+  // ──────────────────────────────────────────────────────────────────────────
+  // GROUP 1: Sliver / CustomScrollView tracking
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Sliver tracking', () {
+    testWidgets(
+      'CustomScrollView with SliverList.builder tracks deferred accesses',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  return CustomScrollView(
+                    slivers: [
+                      SliverList.builder(
+                        itemCount: vm.items.value.length,
+                        itemBuilder: (context, index) {
+                          final isH =
+                              vm.items.value[index] == vm.highlight.value;
+                          return Text(
+                            '${vm.items.value[index]}${isH ? " *" : ""}',
+                          );
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('a *'), findsOneWidget);
+
+        vm.highlight.value = 'c';
+        await tester.pump();
+
+        expect(builds, 2);
+        expect(find.text('c *'), findsOneWidget);
+        expect(find.text('a'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'CustomScrollView with SliverGrid.builder tracks deferred accesses',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  return CustomScrollView(
+                    slivers: [
+                      SliverGrid.builder(
+                        gridDelegate:
+                            const SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: 2,
+                        ),
+                        itemCount: vm.items.value.length,
+                        itemBuilder: (context, index) {
+                          final isH =
+                              vm.items.value[index] == vm.highlight.value;
+                          return Text(
+                            '${vm.items.value[index]}${isH ? " *" : ""}',
+                          );
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('a *'), findsOneWidget);
+
+        vm.highlight.value = 'b';
+        await tester.pump();
+
+        expect(builds, 2);
+        expect(find.text('b *'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'CustomScrollView with multiple slivers tracks all deferred accesses',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  return CustomScrollView(
+                    slivers: [
+                      // Fixed sliver reading label
+                      SliverToBoxAdapter(
+                        child: Text('Label: ${vm.label.value}'),
+                      ),
+                      // Dynamic sliver reading highlight in builder
+                      SliverList.builder(
+                        itemCount: vm.items.value.length,
+                        itemBuilder: (context, index) {
+                          final isH =
+                              vm.items.value[index] == vm.highlight.value;
+                          return Text(
+                            '${vm.items.value[index]}${isH ? " *" : ""}',
+                          );
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('Label: hello'), findsOneWidget);
+
+        // Change highlight — should rebuild via deferred tracking
+        vm.highlight.value = 'b';
+        await tester.pump();
+
+        expect(builds, 2);
+        expect(find.text('b *'), findsOneWidget);
+
+        // Change label — should rebuild via direct tracking
+        vm.label.value = 'world';
+        await tester.pump();
+
+        expect(builds, 3);
+        expect(find.text('Label: world'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'SliverList.separated tracks both item and separator builders',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  return CustomScrollView(
+                    slivers: [
+                      SliverList.separated(
+                        itemCount: vm.items.value.length,
+                        itemBuilder: (context, index) {
+                          return Text(vm.items.value[index]);
+                        },
+                        separatorBuilder: (context, index) {
+                          return Text(vm.separator.value);
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('a'), findsOneWidget);
+        expect(find.text('---'), findsNWidgets(2));
+
+        // Change separator — should rebuild
+        vm.separator.value = '***';
+        await tester.pump();
+
+        expect(builds, 2);
+        expect(find.text('***'), findsNWidgets(2));
+        expect(find.text('---'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Nested CustomScrollView inside ListView.builder tracks correctly',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  return ListView.builder(
+                    itemCount: 1, // single item wrapping a CustomScrollView
+                    itemBuilder: (context, index) {
+                      return SizedBox(
+                        height: 300,
+                        child: CustomScrollView(
+                          slivers: [
+                            SliverList.builder(
+                              itemCount: vm.items.value.length,
+                              itemBuilder: (ctx, i) {
+                                final isH =
+                                    vm.items.value[i] == vm.highlight.value;
+                                return Text(
+                                  '${vm.items.value[i]}${isH ? " *" : ""}',
+                                );
+                              },
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('a *'), findsOneWidget);
+
+        vm.highlight.value = 'c';
+        await tester.pump();
+
+        expect(builds, 2);
+        expect(find.text('c *'), findsOneWidget);
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GROUP 2: Multiple Bind.viewModel widgets with deferred builders
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Multi-widget deferred tracking isolation', () {
+    testWidgets(
+      'Two sibling Bind.viewModel with ListView.builder — independent tracking',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var buildsA = 0;
+        var buildsB = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Column(
+                children: [
+                  // Widget A — reads highlight in deferred builder
+                  Expanded(
+                    child: Bind.viewModel<_ItemsViewModel>(
+                      builder: (context, vm) {
+                        buildsA++;
+                        return ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            final isH =
+                                vm.items.value[index] == vm.highlight.value;
+                            return Text(
+                              'A:${vm.items.value[index]}${isH ? " *" : ""}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  // Widget B — reads separator in deferred builder
+                  Expanded(
+                    child: Bind.viewModel<_ItemsViewModel>(
+                      builder: (context, vm) {
+                        buildsB++;
+                        return ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'B:${vm.items.value[index]} ${vm.separator.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(buildsA, 1);
+        expect(buildsB, 1);
+
+        // Change highlight — only Widget A should rebuild
+        vm.highlight.value = 'b';
+        await tester.pump();
+
+        expect(buildsA, 2,
+            reason: 'A reads highlight in deferred builder');
+        expect(buildsB, 1,
+            reason: 'B does NOT read highlight');
+
+        // Change separator — only Widget B should rebuild
+        vm.separator.value = '===';
+        await tester.pump();
+
+        expect(buildsA, 2,
+            reason: 'A does NOT read separator');
+        expect(buildsB, 2,
+            reason: 'B reads separator in deferred builder');
+      },
+    );
+
+    testWidgets(
+      'Three widgets: direct + deferred + deferred — isolated sessions',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var buildsA = 0;
+        var buildsB = 0;
+        var buildsC = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Column(
+                children: [
+                  // A: direct label read
+                  Bind.viewModel<_ItemsViewModel>(
+                    builder: (context, vm) {
+                      buildsA++;
+                      return Text('A:${vm.label.value}');
+                    },
+                  ),
+                  // B: deferred highlight read
+                  Expanded(
+                    child: Bind.viewModel<_ItemsViewModel>(
+                      builder: (context, vm) {
+                        buildsB++;
+                        return ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            final isH =
+                                vm.items.value[index] == vm.highlight.value;
+                            return Text(
+                              'B:${vm.items.value[index]}${isH ? " *" : ""}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  // C: deferred separator read
+                  Expanded(
+                    child: Bind.viewModel<_ItemsViewModel>(
+                      builder: (context, vm) {
+                        buildsC++;
+                        return ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'C:${vm.items.value[index]} ${vm.separator.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(buildsA, 1);
+        expect(buildsB, 1);
+        expect(buildsC, 1);
+
+        // Change label — only A rebuilds
+        vm.label.value = 'changed';
+        await tester.pump();
+        expect(buildsA, 2);
+        expect(buildsB, 1);
+        expect(buildsC, 1);
+
+        // Change highlight — only B rebuilds
+        vm.highlight.value = 'c';
+        await tester.pump();
+        expect(buildsA, 2);
+        expect(buildsB, 2);
+        expect(buildsC, 1);
+
+        // Change separator — only C rebuilds
+        vm.separator.value = '+++';
+        await tester.pump();
+        expect(buildsA, 2);
+        expect(buildsB, 2);
+        expect(buildsC, 2);
+      },
+    );
+
+    testWidgets(
+      'Two widgets with different VMs, each with deferred builder — no cross-contamination',
+      (tester) async {
+        final vmItems = _ItemsViewModel();
+        final vmOther = _OtherViewModel();
+        var buildsItems = 0;
+        var buildsOther = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [
+                (_) => vmItems,
+                (_) => vmOther,
+              ],
+              child: Column(
+                children: [
+                  Expanded(
+                    child: Bind.viewModel<_ItemsViewModel>(
+                      builder: (context, vm) {
+                        buildsItems++;
+                        return ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'Item:${vm.items.value[index]} ${vm.highlight.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  Bind.viewModel<_OtherViewModel>(
+                    builder: (context, vm) {
+                      buildsOther++;
+                      return Text('Other:${vm.text.value}');
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(buildsItems, 1);
+        expect(buildsOther, 1);
+
+        // Change items VM property — only items widget rebuilds
+        vmItems.highlight.value = 'b';
+        await tester.pump();
+        expect(buildsItems, 2);
+        expect(buildsOther, 1);
+
+        // Change other VM — only other widget rebuilds
+        vmOther.text.value = 'updated';
+        await tester.pump();
+        expect(buildsItems, 2);
+        expect(buildsOther, 2);
+      },
+    );
+
+    testWidgets(
+      'Bind.viewModel with both direct and deferred access — both properties tracked',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  return Column(
+                    children: [
+                      // Direct access
+                      Text('Label: ${vm.label.value}'),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            // Deferred access
+                            return Text(
+                              '${vm.items.value[index]} ${vm.highlight.value}',
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+
+        // Direct property change triggers rebuild
+        vm.label.value = 'new label';
+        await tester.pump();
+        expect(builds, 2);
+
+        // Deferred property change also triggers rebuild
+        vm.highlight.value = 'b';
+        await tester.pump();
+        expect(builds, 3);
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GROUP 3: Nested Bind + Command inside Bind.viewModel
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Nested Bind/Command inside Bind.viewModel — session isolation', () {
+    testWidgets(
+      'Bind inside Bind.viewModel with ListView.builder — child does not pollute parent',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var outerBuilds = 0;
+        var innerBuilds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  outerBuilds++;
+                  return Column(
+                    children: [
+                      // Inner Bind subscribes to label only
+                      Bind<_ItemsViewModel, String>(
+                        bind: (vm) => vm.label,
+                        builder: (context, value, update) {
+                          innerBuilds++;
+                          return Text('Inner: $value');
+                        },
+                      ),
+                      // Outer has deferred builder reading highlight
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              '${vm.items.value[index]} ${vm.highlight.value}',
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(outerBuilds, 1);
+        expect(innerBuilds, 1);
+
+        // Change label — inner rebuilds but outer should NOT
+        // (label is accessed in inner Bind's selector, not outer builder)
+        vm.label.value = 'updated';
+        await tester.pump();
+        expect(outerBuilds, 1, reason: 'Outer does not access label');
+        expect(innerBuilds, 2, reason: 'Inner subscribes to label');
+
+        // Change highlight — outer rebuilds (deferred), inner does NOT
+        vm.highlight.value = 'c';
+        await tester.pump();
+        expect(outerBuilds, 2, reason: 'Outer reads highlight in deferred');
+        // Inner may or may not rebuild depending on whether outer rebuild
+        // causes it. The key assertion is outerBuilds incremented.
+      },
+    );
+
+    testWidgets(
+      'Command inside Bind.viewModel — canExecute does not leak into parent session',
+      (tester) async {
+        final vm = _CommandViewModel();
+        var outerBuilds = 0;
+        var cmdBuilds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_CommandViewModel>(
+                builder: (context, vm) {
+                  outerBuilds++;
+                  return Column(
+                    children: [
+                      Command<_CommandViewModel>(
+                        command: (vm) => vm.doAction,
+                        builder: (context, execute, canExecute, isRunning) {
+                          cmdBuilds++;
+                          return ElevatedButton(
+                            onPressed: canExecute ? execute : null,
+                            child:
+                                Text('Can: $canExecute Running: $isRunning'),
+                          );
+                        },
+                      ),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(vm.items.value[index]);
+                          },
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(outerBuilds, 1);
+        expect(cmdBuilds, 1);
+        expect(find.text('Can: true Running: false'), findsOneWidget);
+
+        // Change canExecute — Command rebuilds, outer should NOT
+        vm.enabled.value = false;
+        vm.doAction.notifyCanExecuteChanged();
+        await tester.pump();
+
+        expect(cmdBuilds, 2, reason: 'Command subscribes to doAction');
+        expect(find.text('Can: false Running: false'), findsOneWidget);
+        // outerBuilds may increment because outer subscribes to vm itself.
+        // The key test: if it does NOT increment, canExecute didn't leak.
+        // If it does, that's the ViewModel-level subscription, not leakage.
+      },
+    );
+
+    testWidgets(
+      'AsyncCommand inside Bind.viewModel — isRunning does not leak into parent session',
+      (tester) async {
+        final vm = _CommandViewModel();
+        var outerBuilds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_CommandViewModel>(
+                builder: (context, vm) {
+                  outerBuilds++;
+                  return Column(
+                    children: [
+                      Command<_CommandViewModel>(
+                        command: (vm) => vm.doAsync,
+                        builder: (context, execute, canExecute, isRunning) {
+                          return ElevatedButton(
+                            onPressed: canExecute ? execute : null,
+                            child: Text(isRunning ? 'Running...' : 'Go'),
+                          );
+                        },
+                      ),
+                      Text('Items: ${vm.items.value.length}'),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        final initialOuterBuilds = outerBuilds;
+
+        // Execute async command
+        await tester.tap(find.byType(ElevatedButton));
+        await tester.pump();
+
+        // The command widget should show running state
+        expect(find.text('Running...'), findsOneWidget);
+
+        // Complete the async action
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.pump();
+
+        expect(find.text('Go'), findsOneWidget);
+
+        // Outer should NOT have rebuilt due to isRunning changes
+        // (only if items or vm itself changed externally)
+        expect(
+          outerBuilds,
+          initialOuterBuilds,
+          reason:
+              'isRunning accesses inside Command widget should not leak to outer',
+        );
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GROUP 4: Conditional rendering & visibility changes
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Conditional rendering and dynamic widget tree', () {
+    testWidgets(
+      'Toggle between ListView and static content — tracking adjusts correctly',
+      (tester) async {
+        final vm = _ToggleViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ToggleViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  if (vm.showList.value) {
+                    return ListView.builder(
+                      itemCount: vm.items.value.length,
+                      itemBuilder: (context, index) {
+                        final isM =
+                            vm.items.value[index] == vm.marker.value;
+                        return Text(
+                          '${vm.items.value[index]}${isM ? " *" : ""}',
+                        );
+                      },
+                    );
+                  } else {
+                    return Text('Static: ${vm.marker.value}');
+                  }
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('1 *'), findsOneWidget);
+
+        // Change marker while list is shown — should rebuild
+        vm.marker.value = '2';
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('2 *'), findsOneWidget);
+
+        // Switch to static view
+        vm.showList.value = false;
+        await tester.pump();
+        expect(builds, 3);
+        expect(find.text('Static: 2'), findsOneWidget);
+
+        // Change marker while static — should still rebuild
+        vm.marker.value = '3';
+        await tester.pump();
+        expect(builds, 4);
+        expect(find.text('Static: 3'), findsOneWidget);
+
+        // Switch back to list
+        vm.showList.value = true;
+        await tester.pump();
+        expect(builds, 5);
+        expect(find.text('3 *'), findsOneWidget);
+
+        // Change marker again after switching back
+        vm.marker.value = '1';
+        await tester.pump();
+        expect(builds, 6);
+        expect(find.text('1 *'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Widget removed from tree — no leak, re-added works correctly',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var builds = 0;
+        var showWidget = true;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: StatefulBuilder(
+                builder: (context, setState2) {
+                  return Column(
+                    children: [
+                      ElevatedButton(
+                        onPressed: () =>
+                            setState2(() => showWidget = !showWidget),
+                        child: const Text('Toggle'),
+                      ),
+                      if (showWidget)
+                        Expanded(
+                          child: Bind.viewModel<_ItemsViewModel>(
+                            builder: (context, vm) {
+                              builds++;
+                              return ListView.builder(
+                                itemCount: vm.items.value.length,
+                                itemBuilder: (context, index) {
+                                  return Text(
+                                    '${vm.items.value[index]} ${vm.highlight.value}',
+                                  );
+                                },
+                              );
+                            },
+                          ),
+                        ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+
+        // Change highlight — should rebuild while mounted
+        vm.highlight.value = 'b';
+        await tester.pump();
+        expect(builds, 2);
+
+        // Remove widget from tree
+        await tester.tap(find.text('Toggle'));
+        await tester.pump();
+
+        final buildsAfterRemove = builds;
+
+        // Change highlight while widget is gone — no crash, no rebuild
+        vm.highlight.value = 'c';
+        await tester.pump();
+        expect(builds, buildsAfterRemove);
+
+        // Re-add widget
+        await tester.tap(find.text('Toggle'));
+        await tester.pump();
+        // New initial build
+        expect(builds, buildsAfterRemove + 1);
+
+        // Verify tracking works again
+        vm.highlight.value = 'a';
+        await tester.pump();
+        expect(builds, buildsAfterRemove + 2);
+      },
+    );
+
+    testWidgets(
+      'Tab switch — each tab has Bind.viewModel with ListView.builder, only active tracked',
+      (tester) async {
+        final vm = _TabViewModel();
+        var tabABuilds = 0;
+        var tabBBuilds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_TabViewModel>(
+                builder: (context, vm) {
+                  return Column(
+                    children: [
+                      Row(
+                        children: [
+                          ElevatedButton(
+                            onPressed: () => vm.selectedTab.value = 0,
+                            child: const Text('Tab A'),
+                          ),
+                          ElevatedButton(
+                            onPressed: () => vm.selectedTab.value = 1,
+                            child: const Text('Tab B'),
+                          ),
+                        ],
+                      ),
+                      Expanded(
+                        child: IndexedStack(
+                          index: vm.selectedTab.value,
+                          children: [
+                            Bind.viewModel<_TabViewModel>(
+                              builder: (context, vm) {
+                                tabABuilds++;
+                                return ListView.builder(
+                                  itemCount: vm.tabAItems.value.length,
+                                  itemBuilder: (context, index) {
+                                    return Text(
+                                      'A:${vm.tabAItems.value[index]} ${vm.tabALabel.value}',
+                                    );
+                                  },
+                                );
+                              },
+                            ),
+                            Bind.viewModel<_TabViewModel>(
+                              builder: (context, vm) {
+                                tabBBuilds++;
+                                return ListView.builder(
+                                  itemCount: vm.tabBItems.value.length,
+                                  itemBuilder: (context, index) {
+                                    return Text(
+                                      'B:${vm.tabBItems.value[index]} ${vm.tabBLabel.value}',
+                                    );
+                                  },
+                                );
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        final initialA = tabABuilds;
+        final initialB = tabBBuilds;
+
+        // Change tabALabel — Tab A should rebuild
+        vm.tabALabel.value = 'New A Label';
+        await tester.pump();
+        expect(tabABuilds, initialA + 1);
+
+        // Change tabBLabel — Tab B should rebuild
+        vm.tabBLabel.value = 'New B Label';
+        await tester.pump();
+        expect(tabBBuilds, initialB + 1);
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GROUP 5: Rapid / stress tests
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Rapid changes and stress', () {
+    testWidgets(
+      'Rapid property changes with deferred builder — no crash, correct final state',
+      (tester) async {
+        final vm = _ItemsViewModel();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  return ListView.builder(
+                    itemCount: vm.items.value.length,
+                    itemBuilder: (context, index) {
+                      final isH =
+                          vm.items.value[index] == vm.highlight.value;
+                      return Text(
+                        '${vm.items.value[index]}${isH ? " *" : ""}',
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Rapid changes without pumping between them
+        vm.highlight.value = 'b';
+        vm.highlight.value = 'c';
+        vm.highlight.value = 'a';
+        vm.highlight.value = 'b';
+
+        await tester.pump();
+        expect(find.text('b *'), findsOneWidget);
+        expect(find.text('a'), findsOneWidget);
+        expect(find.text('c'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Growing list items — new items tracked after each addition',
+      (tester) async {
+        final vm = _GrowingListViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_GrowingListViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  return ListView.builder(
+                    itemCount: vm.items.value.length,
+                    itemBuilder: (context, index) {
+                      return Text('${vm.items.value[index]} [${vm.tag.value}]');
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+
+        // Add items
+        vm.items.value = ['item1'];
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('item1 [v1]'), findsOneWidget);
+
+        // Change tag — deferred tracking should catch it
+        vm.tag.value = 'v2';
+        await tester.pump();
+        expect(builds, 3);
+        expect(find.text('item1 [v2]'), findsOneWidget);
+
+        // Add more items
+        vm.items.value = ['item1', 'item2', 'item3'];
+        await tester.pump();
+        expect(find.text('item1 [v2]'), findsOneWidget);
+        expect(find.text('item2 [v2]'), findsOneWidget);
+        expect(find.text('item3 [v2]'), findsOneWidget);
+
+        // Change tag again
+        vm.tag.value = 'v3';
+        await tester.pump();
+        expect(find.text('item1 [v3]'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Empty list then populated — deferred tracking kicks in correctly',
+      (tester) async {
+        final vm = _GrowingListViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_GrowingListViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  return ListView.builder(
+                    itemCount: vm.items.value.length,
+                    itemBuilder: (context, index) {
+                      return Text('${vm.items.value[index]} [${vm.tag.value}]');
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+
+        // tag change when list is empty — should still track items via direct access
+        vm.tag.value = 'v2';
+        await tester.pump();
+        // May or may not rebuild depending on whether tag was accessed
+        // (it wasn't, because itemBuilder never ran with 0 items)
+
+        // Populate list
+        vm.items.value = ['first'];
+        await tester.pump();
+        expect(find.text('first [v2]'), findsOneWidget);
+
+        // Now tag change should work since itemBuilder ran
+        vm.tag.value = 'v3';
+        await tester.pump();
+        expect(find.text('first [v3]'), findsOneWidget);
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GROUP 6: Session stack integrity
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Session stack integrity', () {
+    testWidgets(
+      'Deeply nested Bind.viewModel (3 levels) — each tracks independently',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var outerBuilds = 0;
+        var middleBuilds = 0;
+        var innerBuilds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  outerBuilds++;
+                  return Column(
+                    children: [
+                      Text('Outer: ${vm.label.value}'),
+                      Expanded(
+                        child: Bind.viewModel<_ItemsViewModel>(
+                          builder: (context, vm) {
+                            middleBuilds++;
+                            return Column(
+                              children: [
+                                Text('Middle: ${vm.separator.value}'),
+                                Expanded(
+                                  child: Bind.viewModel<_ItemsViewModel>(
+                                    builder: (context, vm) {
+                                      innerBuilds++;
+                                      return ListView.builder(
+                                        itemCount: vm.items.value.length,
+                                        itemBuilder: (context, index) {
+                                          return Text(
+                                            'Inner:${vm.items.value[index]} ${vm.highlight.value}',
+                                          );
+                                        },
+                                      );
+                                    },
+                                  ),
+                                ),
+                              ],
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(outerBuilds, 1);
+        expect(middleBuilds, 1);
+        expect(innerBuilds, 1);
+        expect(find.text('Outer: hello'), findsOneWidget);
+        expect(find.text('Middle: ---'), findsOneWidget);
+        expect(find.text('Inner:a a'), findsOneWidget);
+
+        // Change label — only outer rebuilds (cascades to children via build)
+        vm.label.value = 'changed';
+        await tester.pump();
+        expect(outerBuilds, 2);
+        // Middle and inner get recreated as part of outer's subtree rebuild
+        // That's expected Flutter behavior
+
+        // Reset counts
+        final savedMiddle = middleBuilds;
+        final savedInner = innerBuilds;
+
+        // Change separator — middle tracks it directly
+        vm.separator.value = '***';
+        await tester.pump();
+        expect(outerBuilds, 2, reason: 'Outer does NOT read separator');
+        expect(middleBuilds, savedMiddle + 1);
+
+        // Change highlight — inner tracks it in deferred builder
+        final savedOuter2 = outerBuilds;
+        final savedMiddle2 = middleBuilds;
+        vm.highlight.value = 'c';
+        await tester.pump();
+        expect(outerBuilds, savedOuter2, reason: 'Outer does NOT read highlight');
+        expect(middleBuilds, savedMiddle2, reason: 'Middle does NOT read highlight');
+        expect(innerBuilds, savedInner + 2, // +1 from separator change, +1 from highlight
+            reason: 'Inner reads highlight in deferred builder');
+      },
+    );
+
+    testWidgets(
+      'Bind.viewModel2 with lazy builder in both VMs — tracks correctly',
+      (tester) async {
+        final vmItems = _ItemsViewModel();
+        final vmOther = _OtherViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [
+                (_) => vmItems,
+                (_) => vmOther,
+              ],
+              child: Bind.viewModel2<_ItemsViewModel, _OtherViewModel>(
+                builder: (context, items, other) {
+                  builds++;
+                  return Column(
+                    children: [
+                      Text('Other: ${other.text.value}'),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: items.items.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              '${items.items.value[index]} ${items.highlight.value}',
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+
+        // Change deferred property — should rebuild
+        vmItems.highlight.value = 'b';
+        await tester.pump();
+        expect(builds, 2);
+
+        // Change direct property from other VM — should rebuild
+        vmOther.text.value = 'updated';
+        await tester.pump();
+        expect(builds, 3);
+        expect(find.text('Other: updated'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Parallel sibling Bind.viewModel with GridView and ListView — isolated',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var listBuilds = 0;
+        var gridBuilds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Column(
+                children: [
+                  Expanded(
+                    child: Bind.viewModel<_ItemsViewModel>(
+                      builder: (context, vm) {
+                        listBuilds++;
+                        return ListView.builder(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'List:${vm.items.value[index]} ${vm.highlight.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  Expanded(
+                    child: Bind.viewModel<_ItemsViewModel>(
+                      builder: (context, vm) {
+                        gridBuilds++;
+                        return GridView.builder(
+                          gridDelegate:
+                              const SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 2,
+                          ),
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'Grid:${vm.items.value[index]} ${vm.separator.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(listBuilds, 1);
+        expect(gridBuilds, 1);
+
+        // Change highlight — only list rebuilds
+        vm.highlight.value = 'c';
+        await tester.pump();
+        expect(listBuilds, 2);
+        expect(gridBuilds, 1, reason: 'Grid does NOT read highlight');
+
+        // Change separator — only grid rebuilds
+        vm.separator.value = '|||';
+        await tester.pump();
+        expect(listBuilds, 2, reason: 'List does NOT read separator');
+        expect(gridBuilds, 2);
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GROUP 7: Edge cases — exceptions, empty states, widget key changes
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Edge cases', () {
+    testWidgets(
+      'ListView.builder with 0 items — tracker does not crash on rebuild',
+      (tester) async {
+        final vm = _GrowingListViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_GrowingListViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  return ListView.builder(
+                    itemCount: vm.items.value.length,
+                    itemBuilder: (context, index) {
+                      return Text('${vm.items.value[index]} [${vm.tag.value}]');
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+
+        // Force rebuild via items change (add then remove)
+        vm.items.value = ['temp'];
+        await tester.pump();
+        expect(builds, 2);
+
+        vm.items.value = [];
+        await tester.pump();
+        // No crash expected
+        expect(builds, 3);
+
+        // Now add items
+        vm.items.value = ['hello'];
+        await tester.pump();
+        expect(find.text('hello [v1]'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Widget with key change — re-creates element, tracking re-initializes',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var builds = 0;
+        var currentKey = const ValueKey('v1');
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: StatefulBuilder(
+                builder: (context, setState2) {
+                  return Column(
+                    children: [
+                      ElevatedButton(
+                        onPressed: () => setState2(
+                            () => currentKey = const ValueKey('v2')),
+                        child: const Text('Change Key'),
+                      ),
+                      Expanded(
+                        child: Bind.viewModel<_ItemsViewModel>(
+                          key: currentKey,
+                          builder: (context, vm) {
+                            builds++;
+                            return ListView.builder(
+                              itemCount: vm.items.value.length,
+                              itemBuilder: (context, index) {
+                                return Text(
+                                  '${vm.items.value[index]} ${vm.highlight.value}',
+                                );
+                              },
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+
+        // Tracking works
+        vm.highlight.value = 'b';
+        await tester.pump();
+        expect(builds, 2);
+
+        // Change key — forces full re-creation
+        await tester.tap(find.text('Change Key'));
+        await tester.pump();
+        final buildsAfterKeyChange = builds;
+
+        // Tracking still works on new element
+        vm.highlight.value = 'c';
+        await tester.pump();
+        expect(builds, buildsAfterKeyChange + 1);
+      },
+    );
+
+    testWidgets(
+      'Multiple rapid mount/unmount cycles — no context stack leak',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var showWidget = true;
+
+        for (var i = 0; i < 10; i++) {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: FairyScope(
+                viewModel: (_) => vm,
+                child: showWidget
+                    ? Bind.viewModel<_ItemsViewModel>(
+                        builder: (context, vm) {
+                          return ListView.builder(
+                            itemCount: vm.items.value.length,
+                            itemBuilder: (context, index) {
+                              return Text(
+                                '${vm.items.value[index]} ${vm.highlight.value}',
+                              );
+                            },
+                          );
+                        },
+                      )
+                    : const SizedBox.shrink(),
+              ),
+            ),
+          );
+          showWidget = !showWidget;
+        }
+
+        // After many mount/unmounts, verify no crash and tracking still works
+        // showWidget is now false (10 toggles from true)
+        showWidget = true;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  return ListView.builder(
+                    itemCount: vm.items.value.length,
+                    itemBuilder: (context, index) {
+                      return Text(
+                        '${vm.items.value[index]} ${vm.highlight.value}',
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('a a'), findsOneWidget);
+
+        vm.highlight.value = 'c';
+        await tester.pump();
+        expect(find.text('a c'), findsOneWidget);
+        expect(find.text('c c'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'ListView.separated inside Bind.viewModel alongside sibling Bind.viewModel — separator accesses isolated',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var listBuilds = 0;
+        var siblingBuilds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Column(
+                children: [
+                  Expanded(
+                    child: Bind.viewModel<_ItemsViewModel>(
+                      builder: (context, vm) {
+                        listBuilds++;
+                        return ListView.separated(
+                          itemCount: vm.items.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(vm.items.value[index]);
+                          },
+                          separatorBuilder: (context, index) {
+                            return Text(vm.separator.value);
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  Bind.viewModel<_ItemsViewModel>(
+                    builder: (context, vm) {
+                      siblingBuilds++;
+                      return Text('Sibling: ${vm.label.value}');
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(listBuilds, 1);
+        expect(siblingBuilds, 1);
+
+        // Change separator — only list rebuilds
+        vm.separator.value = '===';
+        await tester.pump();
+        expect(listBuilds, 2);
+        expect(siblingBuilds, 1,
+            reason: 'Sibling does NOT read separator');
+
+        // Change label — only sibling rebuilds
+        vm.label.value = 'new';
+        await tester.pump();
+        expect(listBuilds, 2, reason: 'List does NOT read label');
+        expect(siblingBuilds, 2);
+      },
+    );
+
+    testWidgets(
+      'Bind.viewModel with ListView.builder inside Scaffold body and appBar — both track correctly',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var bodyBuilds = 0;
+        var appBarBuilds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Scaffold(
+                appBar: PreferredSize(
+                  preferredSize: const Size.fromHeight(56),
+                  child: Bind.viewModel<_ItemsViewModel>(
+                    builder: (context, vm) {
+                      appBarBuilds++;
+                      return AppBar(title: Text(vm.label.value));
+                    },
+                  ),
+                ),
+                body: Bind.viewModel<_ItemsViewModel>(
+                  builder: (context, vm) {
+                    bodyBuilds++;
+                    return ListView.builder(
+                      itemCount: vm.items.value.length,
+                      itemBuilder: (context, index) {
+                        final isH =
+                            vm.items.value[index] == vm.highlight.value;
+                        return Text(
+                          '${vm.items.value[index]}${isH ? " *" : ""}',
+                        );
+                      },
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+
+        expect(bodyBuilds, 1);
+        expect(appBarBuilds, 1);
+
+        // Change highlight — only body rebuilds
+        vm.highlight.value = 'b';
+        await tester.pump();
+        expect(bodyBuilds, 2);
+        expect(appBarBuilds, 1, reason: 'AppBar does NOT read highlight');
+
+        // Change label — only appBar rebuilds
+        vm.label.value = 'New Title';
+        await tester.pump();
+        expect(bodyBuilds, 2, reason: 'Body does NOT read label');
+        expect(appBarBuilds, 2);
+      },
+    );
+
+    testWidgets(
+      'PageView.builder with deferred tracking — accesses captured',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  return SizedBox(
+                    height: 400,
+                    child: PageView.builder(
+                      itemCount: vm.items.value.length,
+                      itemBuilder: (context, index) {
+                        return Center(
+                          child: Text(
+                            '${vm.items.value[index]} ${vm.highlight.value}',
+                          ),
+                        );
+                      },
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('a a'), findsOneWidget);
+
+        vm.highlight.value = 'new';
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('a new'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Bind.viewModel reading only in itemBuilder (no direct/sync access) — still tracked',
+      (tester) async {
+        final vm = _ItemsViewModel();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModel: (_) => vm,
+              child: Bind.viewModel<_ItemsViewModel>(
+                builder: (context, vm) {
+                  builds++;
+                  // NOTE: vm is intentionally NOT accessed synchronously
+                  // (except for the implicit ViewModel-level DependencyTracker.reportAccess(vm))
+                  return ListView.builder(
+                    itemCount: 3,
+                    itemBuilder: (context, index) {
+                      // ALL observable accesses happen here (deferred)
+                      return Text(
+                        '${vm.items.value[index]} ${vm.highlight.value} ${vm.label.value}',
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+
+        // Each deferred property change should cause a rebuild
+        vm.highlight.value = 'X';
+        await tester.pump();
+        expect(builds, 2);
+
+        vm.label.value = 'Y';
+        await tester.pump();
+        expect(builds, 3);
+
+        vm.items.value = ['d', 'e', 'f'];
+        await tester.pump();
+        expect(builds, 4);
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GROUP 8: Bind.viewModel2 — deferred tracking with two VMs
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Bind.viewModel2 — deferred tracking', () {
+    testWidgets(
+      'ListView.builder accessing properties from both VMs — all tracked',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB],
+              child: Bind.viewModel2<_VmA, _VmB>(
+                builder: (context, a, b) {
+                  builds++;
+                  return ListView.builder(
+                    itemCount: a.listItems.value.length,
+                    itemBuilder: (context, index) {
+                      return Text(
+                        '${b.prefix.value} ${a.listItems.value[index]} ${a.badge.value}',
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('>> a !'), findsOneWidget);
+
+        // Change VmA deferred-only property
+        vmA.badge.value = '*';
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('>> a *'), findsOneWidget);
+
+        // Change VmB deferred-only property
+        vmB.prefix.value = '##';
+        await tester.pump();
+        expect(builds, 3);
+        expect(find.text('## a *'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Sibling Bind.viewModel2 widgets — deferred accesses isolated per widget',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        var buildsW1 = 0;
+        var buildsW2 = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB],
+              child: Column(
+                children: [
+                  // W1: reads badge in deferred builder
+                  Expanded(
+                    child: Bind.viewModel2<_VmA, _VmB>(
+                      builder: (context, a, b) {
+                        buildsW1++;
+                        return ListView.builder(
+                          itemCount: a.listItems.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'W1:${a.listItems.value[index]} ${a.badge.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  // W2: reads prefix in deferred builder
+                  Expanded(
+                    child: Bind.viewModel2<_VmA, _VmB>(
+                      builder: (context, a, b) {
+                        buildsW2++;
+                        return ListView.builder(
+                          itemCount: a.listItems.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'W2:${a.listItems.value[index]} ${b.prefix.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(buildsW1, 1);
+        expect(buildsW2, 1);
+
+        // Change badge — only W1 rebuilds
+        vmA.badge.value = '?';
+        await tester.pump();
+        expect(buildsW1, 2, reason: 'W1 reads badge in deferred builder');
+        expect(buildsW2, 1, reason: 'W2 does NOT read badge');
+
+        // Change prefix — only W2 rebuilds
+        vmB.prefix.value = '@@';
+        await tester.pump();
+        expect(buildsW1, 2, reason: 'W1 does NOT read prefix');
+        expect(buildsW2, 2, reason: 'W2 reads prefix in deferred builder');
+      },
+    );
+
+    testWidgets(
+      'CustomScrollView with SliverList.builder accessing two VMs',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB],
+              child: Bind.viewModel2<_VmA, _VmB>(
+                builder: (context, a, b) {
+                  builds++;
+                  return CustomScrollView(
+                    slivers: [
+                      SliverList.builder(
+                        itemCount: a.listItems.value.length,
+                        itemBuilder: (context, index) {
+                          return Text(
+                            '${b.prefix.value}:${a.listItems.value[index]}',
+                          );
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('>>:a'), findsOneWidget);
+
+        vmB.prefix.value = '<<';
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('<<:a'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'ListView.separated accessing both VMs in itemBuilder and separatorBuilder',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB],
+              child: Bind.viewModel2<_VmA, _VmB>(
+                builder: (context, a, b) {
+                  builds++;
+                  return ListView.separated(
+                    itemCount: a.listItems.value.length,
+                    itemBuilder: (context, index) {
+                      return Text(
+                        '${a.listItems.value[index]} ${a.badge.value}',
+                      );
+                    },
+                    separatorBuilder: (context, index) {
+                      return Text(b.prefix.value);
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('a !'), findsOneWidget);
+        expect(find.text('>>'), findsNWidgets(2));
+
+        // Change separator VM property
+        vmB.prefix.value = '---';
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('---'), findsNWidgets(2));
+
+        // Change item VM property
+        vmA.badge.value = '#';
+        await tester.pump();
+        expect(builds, 3);
+        expect(find.text('a #'), findsOneWidget);
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GROUP 9: Bind.viewModel3 — deferred tracking with three VMs
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Bind.viewModel3 — deferred tracking', () {
+    testWidgets(
+      'ListView.builder accessing three VMs — all deferred accesses tracked',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        final vmC = _VmC();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB, (_) => vmC],
+              child: Bind.viewModel3<_VmA, _VmB, _VmC>(
+                builder: (context, a, b, c) {
+                  builds++;
+                  return ListView.builder(
+                    itemCount: a.listItems.value.length,
+                    itemBuilder: (context, index) {
+                      return Text(
+                        '${b.prefix.value} ${a.listItems.value[index]} ${c.sep.value}',
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('>> a |'), findsOneWidget);
+
+        // Each VM's deferred property should trigger rebuild
+        vmA.badge.value = '?'; // badge not accessed — should NOT rebuild
+        await tester.pump();
+        expect(builds, 1, reason: 'badge not accessed in builder');
+
+        vmB.prefix.value = '!!';
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('!! a |'), findsOneWidget);
+
+        vmC.sep.value = '~';
+        await tester.pump();
+        expect(builds, 3);
+        expect(find.text('!! a ~'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Sibling Bind.viewModel3 — deferred property isolation',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        final vmC = _VmC();
+        var buildsW1 = 0;
+        var buildsW2 = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB, (_) => vmC],
+              child: Column(
+                children: [
+                  // W1: reads badge + sep in deferred
+                  Expanded(
+                    child: Bind.viewModel3<_VmA, _VmB, _VmC>(
+                      builder: (context, a, b, c) {
+                        buildsW1++;
+                        return ListView.builder(
+                          itemCount: a.listItems.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'W1:${a.listItems.value[index]} ${a.badge.value} ${c.sep.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  // W2: reads prefix + count in deferred
+                  Expanded(
+                    child: Bind.viewModel3<_VmA, _VmB, _VmC>(
+                      builder: (context, a, b, c) {
+                        buildsW2++;
+                        return ListView.builder(
+                          itemCount: a.listItems.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'W2:${a.listItems.value[index]} ${b.prefix.value} ${b.count.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(buildsW1, 1);
+        expect(buildsW2, 1);
+
+        // Change badge — only W1 rebuilds
+        vmA.badge.value = '?';
+        await tester.pump();
+        expect(buildsW1, 2);
+        expect(buildsW2, 1);
+
+        // Change count — only W2 rebuilds
+        vmB.count.value = 42;
+        await tester.pump();
+        expect(buildsW1, 2);
+        expect(buildsW2, 2);
+
+        // Change sep — only W1 rebuilds
+        vmC.sep.value = '~';
+        await tester.pump();
+        expect(buildsW1, 3);
+        expect(buildsW2, 2);
+
+        // Change prefix — only W2 rebuilds
+        vmB.prefix.value = '@@';
+        await tester.pump();
+        expect(buildsW1, 3);
+        expect(buildsW2, 3);
+      },
+    );
+
+    testWidgets(
+      'CustomScrollView with SliverList.separated — three VMs tracked',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        final vmC = _VmC();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB, (_) => vmC],
+              child: Bind.viewModel3<_VmA, _VmB, _VmC>(
+                builder: (context, a, b, c) {
+                  builds++;
+                  return CustomScrollView(
+                    slivers: [
+                      SliverList.separated(
+                        itemCount: a.listItems.value.length,
+                        itemBuilder: (context, index) {
+                          return Text(
+                            '${b.prefix.value} ${a.listItems.value[index]}',
+                          );
+                        },
+                        separatorBuilder: (context, index) {
+                          return Text(c.sep.value);
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('>> a'), findsOneWidget);
+        expect(find.text('|'), findsNWidgets(2));
+
+        vmC.sep.value = '---';
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('---'), findsNWidgets(2));
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GROUP 10: Bind.viewModel4 — deferred tracking with four VMs
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Bind.viewModel4 — deferred tracking', () {
+    testWidgets(
+      'ListView.builder accessing four VMs — all deferred accesses tracked',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        final vmC = _VmC();
+        final vmD = _VmD();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB, (_) => vmC, (_) => vmD],
+              child: Bind.viewModel4<_VmA, _VmB, _VmC, _VmD>(
+                builder: (context, a, b, c, d) {
+                  builds++;
+                  return ListView.builder(
+                    itemCount: a.listItems.value.length,
+                    itemBuilder: (context, index) {
+                      return Text(
+                        '${b.prefix.value}${a.listItems.value[index]}${c.sep.value}${d.suffix.value}',
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('>>a|.'), findsOneWidget);
+
+        // Each deferred property change triggers rebuild
+        vmB.prefix.value = '<<';
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('<<a|.'), findsOneWidget);
+
+        vmC.sep.value = '-';
+        await tester.pump();
+        expect(builds, 3);
+        expect(find.text('<<a-.'), findsOneWidget);
+
+        vmD.suffix.value = '!';
+        await tester.pump();
+        expect(builds, 4);
+        expect(find.text('<<a-!'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Sibling Bind.viewModel4 — per-widget deferred isolation',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        final vmC = _VmC();
+        final vmD = _VmD();
+        var buildsW1 = 0;
+        var buildsW2 = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB, (_) => vmC, (_) => vmD],
+              child: Column(
+                children: [
+                  // W1: reads badge + sep in deferred
+                  Expanded(
+                    child: Bind.viewModel4<_VmA, _VmB, _VmC, _VmD>(
+                      builder: (context, a, b, c, d) {
+                        buildsW1++;
+                        return ListView.builder(
+                          itemCount: a.listItems.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'W1:${a.listItems.value[index]} ${a.badge.value} ${c.sep.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  // W2: reads prefix + suffix in deferred
+                  Expanded(
+                    child: Bind.viewModel4<_VmA, _VmB, _VmC, _VmD>(
+                      builder: (context, a, b, c, d) {
+                        buildsW2++;
+                        return ListView.builder(
+                          itemCount: a.listItems.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'W2:${a.listItems.value[index]} ${b.prefix.value} ${d.suffix.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(buildsW1, 1);
+        expect(buildsW2, 1);
+
+        // badge — only W1
+        vmA.badge.value = '?';
+        await tester.pump();
+        expect(buildsW1, 2);
+        expect(buildsW2, 1);
+
+        // suffix — only W2
+        vmD.suffix.value = '!!';
+        await tester.pump();
+        expect(buildsW1, 2);
+        expect(buildsW2, 2);
+
+        // sep — only W1
+        vmC.sep.value = '~';
+        await tester.pump();
+        expect(buildsW1, 3);
+        expect(buildsW2, 2);
+
+        // prefix — only W2
+        vmB.prefix.value = '@@';
+        await tester.pump();
+        expect(buildsW1, 3);
+        expect(buildsW2, 3);
+      },
+    );
+
+    testWidgets(
+      'ListView.separated with four VMs — both builders track all VMs',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        final vmC = _VmC();
+        final vmD = _VmD();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB, (_) => vmC, (_) => vmD],
+              child: Bind.viewModel4<_VmA, _VmB, _VmC, _VmD>(
+                builder: (context, a, b, c, d) {
+                  builds++;
+                  return ListView.separated(
+                    itemCount: a.listItems.value.length,
+                    itemBuilder: (context, index) {
+                      return Text(
+                        '${b.prefix.value}:${a.listItems.value[index]} ${d.suffix.value}',
+                      );
+                    },
+                    separatorBuilder: (context, index) {
+                      return Text('${c.sep.value}${d.score.value}');
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('>>:a .'), findsOneWidget);
+        expect(find.text('|100'), findsNWidgets(2));
+
+        // Change separator property in VmC
+        vmC.sep.value = '---';
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('---100'), findsNWidgets(2));
+
+        // Change score in VmD
+        vmD.score.value = 999;
+        await tester.pump();
+        expect(builds, 3);
+        expect(find.text('---999'), findsNWidgets(2));
+
+        // Change suffix in VmD (used in itemBuilder)
+        vmD.suffix.value = '!';
+        await tester.pump();
+        expect(builds, 4);
+        expect(find.text('>>:a !'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'CustomScrollView with SliverGrid.builder + SliverToBoxAdapter — four VMs',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        final vmC = _VmC();
+        final vmD = _VmD();
+        var builds = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB, (_) => vmC, (_) => vmD],
+              child: Bind.viewModel4<_VmA, _VmB, _VmC, _VmD>(
+                builder: (context, a, b, c, d) {
+                  builds++;
+                  return CustomScrollView(
+                    slivers: [
+                      SliverToBoxAdapter(
+                        child: Text('Header: ${b.prefix.value}'),
+                      ),
+                      SliverGrid.builder(
+                        gridDelegate:
+                            const SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: 2,
+                        ),
+                        itemCount: a.listItems.value.length,
+                        itemBuilder: (context, index) {
+                          return Text(
+                            '${a.listItems.value[index]}${c.sep.value}${d.suffix.value}',
+                          );
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(builds, 1);
+        expect(find.text('Header: >>'), findsOneWidget);
+        expect(find.text('a|.'), findsOneWidget);
+
+        // Change direct property (prefix in SliverToBoxAdapter)
+        vmB.prefix.value = '!!';
+        await tester.pump();
+        expect(builds, 2);
+        expect(find.text('Header: !!'), findsOneWidget);
+
+        // Change deferred property (sep in SliverGrid.builder)
+        vmC.sep.value = '-';
+        await tester.pump();
+        expect(builds, 3);
+        expect(find.text('a-.'), findsOneWidget);
+
+        // Change deferred property (suffix in SliverGrid.builder)
+        vmD.suffix.value = '#';
+        await tester.pump();
+        expect(builds, 4);
+        expect(find.text('a-#'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Mixed: Bind.viewModel4 alongside Bind.viewModel — no cross-contamination',
+      (tester) async {
+        final vmA = _VmA();
+        final vmB = _VmB();
+        final vmC = _VmC();
+        final vmD = _VmD();
+        var builds4 = 0;
+        var builds1 = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FairyScope(
+              viewModels: [(_) => vmA, (_) => vmB, (_) => vmC, (_) => vmD],
+              child: Column(
+                children: [
+                  // ViewModel4 reads badge in deferred
+                  Expanded(
+                    child: Bind.viewModel4<_VmA, _VmB, _VmC, _VmD>(
+                      builder: (context, a, b, c, d) {
+                        builds4++;
+                        return ListView.builder(
+                          itemCount: a.listItems.value.length,
+                          itemBuilder: (context, index) {
+                            return Text(
+                              'V4:${a.listItems.value[index]} ${a.badge.value}',
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  // ViewModel1 reads suffix in deferred
+                  Expanded(
+                    child: Bind.viewModel<_VmD>(
+                      builder: (context, d) {
+                        builds1++;
+                        return ListView.builder(
+                          itemCount: 2,
+                          itemBuilder: (context, index) {
+                            return Text('V1:${d.suffix.value}');
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(builds4, 1);
+        expect(builds1, 1);
+
+        // Change badge — only V4 rebuilds
+        vmA.badge.value = '?';
+        await tester.pump();
+        expect(builds4, 2);
+        expect(builds1, 1);
+
+        // Change suffix — only V1 rebuilds
+        vmD.suffix.value = '!!!';
+        await tester.pump();
+        // V4 may also rebuild because it registered vmD in its session,
+        // but badge change should NOT affect V1
+        expect(builds1, 2);
+      },
+    );
+  });
+}


### PR DESCRIPTION
This pull request releases version 3.0.1 of the Fairy MVVM framework for Flutter, focusing on a critical bug fix for dependency tracking in complex widget trees, new developer-facing safeguards, and improved API exports. The most significant update is a robust overhaul of the `DependencyTracker` to prevent cross-widget tracking corruption, especially in scenarios with multiple `Bind.viewModel` widgets. Additionally, new assertions ensure that multi-ViewModel widgets are constructed with unique types, and `BindViewModel4` is now publicly exported. Documentation and benchmarks have also been updated to reflect the new version.

**Dependency tracking and widget isolation improvements:**

- Completely redesigned the `DependencyTracker` to prevent cross-widget tracking corruption. The new approach uses a three-layer system:
  - Custom `_TrackingContextElement` with `update()` and `performRebuild()` overrides for correct build-phase tracking.
  - `_BoxTrackingRenderBox` and `_SliverTrackingRenderBox` for layout-phase tracking, auto-detecting context type.
  - Context stack guards in `Bind` and `Command` widget `build()` methods for session isolation.  
  [[1]](diffhunk://#diff-87770c929f85840359af08c1ff2de23faffbcef4e9b8a63df185a6ff1af3add1R14-R28) [[2]](diffhunk://#diff-87770c929f85840359af08c1ff2de23faffbcef4e9b8a63df185a6ff1af3add1L33-R56) [[3]](diffhunk://#diff-87770c929f85840359af08c1ff2de23faffbcef4e9b8a63df185a6ff1af3add1L118-R140) [[4]](diffhunk://#diff-87770c929f85840359af08c1ff2de23faffbcef4e9b8a63df185a6ff1af3add1L128-L135) [[5]](diffhunk://#diff-87770c929f85840359af08c1ff2de23faffbcef4e9b8a63df185a6ff1af3add1L147-R324)

**API safety and usability enhancements:**

- Added runtime assertions to `Bind.viewModel2`, `Bind.viewModel3`, `Bind.viewModel4` (and their direct constructors) to ensure all ViewModel type parameters are unique, preventing accidental duplicate usage.  
  [[1]](diffhunk://#diff-451d41c80789b60e4b6443306acda75b60d7faf4fc3b2feef2cfaee625c67fceL295-R299) [[2]](diffhunk://#diff-451d41c80789b60e4b6443306acda75b60d7faf4fc3b2feef2cfaee625c67fceL433-R443) [[3]](diffhunk://#diff-451d41c80789b60e4b6443306acda75b60d7faf4fc3b2feef2cfaee625c67fceL578-R597) [[4]](diffhunk://#diff-61a0f790eb71daa6660d52e17b7b9c6b0b7c73a9daf167062e8371ae3b4bf8d3R164-R168) [[5]](diffhunk://#diff-61a0f790eb71daa6660d52e17b7b9c6b0b7c73a9daf167062e8371ae3b4bf8d3R204-R210)
- Publicly exported `BindViewModel4` from the package for advanced use cases.  
 

**Documentation and benchmarks:**

- Updated all documentation and benchmark references to version 3.0.1, including performance metrics and dependency instructions.  
  [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44) [[2]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5L38-R38) [[3]](diffhunk://#diff-7fe6b01752be42136da1c4bfcc273aa482497b35192a5af3fc46027766c59ae1L20-R20) [[4]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5L841-R841)

**Changelog and testing:**

- Added a detailed changelog for 3.0.1, highlighting the bug fix, new features, and extensive new tests (40+ for dependency tracking, 17 for type assertions).  
 

**Internal improvements:**

- Refactored internal logic to use a context stack for layout-phase fallback, removed obsolete context-setting methods, and clarified comments for maintainability.  
  [[1]](diffhunk://#diff-87770c929f85840359af08c1ff2de23faffbcef4e9b8a63df185a6ff1af3add1R14-R28) [[2]](diffhunk://#diff-87770c929f85840359af08c1ff2de23faffbcef4e9b8a63df185a6ff1af3add1L33-R56) [[3]](diffhunk://#diff-87770c929f85840359af08c1ff2de23faffbcef4e9b8a63df185a6ff1af3add1L60-R66)

This release significantly improves the reliability of dependency tracking in complex widget trees, adds developer safeguards, and updates documentation for clarity.